### PR TITLE
Setup command debugging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,8 @@ guidelines on when to use or avoid this directive follow:
 
 - instead of disabling `unused-argument`, prefix the arg (or kwarg) with `_`
 
-- if you _do_ add disable directives, be aware of where you place them.  They can unintentially
-  effect more code than you indend.  The order of precidence should be:
+- if you _do_ add disable directives, be aware of where you place them.  They can unintentionally
+  affect more code than you intended.  The order of precedence should be:
 
   1. inline (only affects the current line)
   1. wrap small bits of code in `# pylint: disable` ... `# pylint: enable` blocks

--- a/runner.py
+++ b/runner.py
@@ -333,7 +333,6 @@ class Runner:
                 # docker exec must stay as list, cause this forces items to be quoted and escaped and prevents
                 # injection of unwanted params
                 try:
-
                     ps = subprocess.run(
                         ['docker', 'exec', container_name, *cmd.split()],
                         check=True,


### PR DESCRIPTION
If the `debug` flag is enabled, the runner will now pause before each setup command and also allow the user to ignore a failing setup command due to a non-zero return code from the setup command subprocess run.