### PR TITLE
Added description field to usage scenarios

### DIFF
--- a/test/data/usage_scenarios/basic_stress.yml
+++ b/test/data/usage_scenarios/basic_stress.yml
@@ -2,6 +2,7 @@
 name: Test Stress
 author: Dan Mateas
 version: 1
+description: test
 
 services:
   test-container:

--- a/test/data/usage_scenarios/basic_stress_w_import.yml
+++ b/test/data/usage_scenarios/basic_stress_w_import.yml
@@ -2,6 +2,7 @@
 name: Test Stress
 author: Dan Mateas
 version: 1
+description: test
 
 compose-file: !include docker-compose-file
 

--- a/test/data/usage_scenarios/cmd_stress.yml
+++ b/test/data/usage_scenarios/cmd_stress.yml
@@ -2,6 +2,7 @@
 name: Test Stress
 author: Dan Mateas
 version: 1
+description: test
 
 services:
   test-container:

--- a/test/data/usage_scenarios/env_vars_stress.yml
+++ b/test/data/usage_scenarios/env_vars_stress.yml
@@ -2,6 +2,7 @@
 name: Test Stress
 author: Dan Mateas
 version: 1
+description: test
 
 services:
   test-container:

--- a/test/data/usage_scenarios/import_two_root.yml
+++ b/test/data/usage_scenarios/import_two_root.yml
@@ -1,5 +1,7 @@
 name: my sample flow
 author: Arne Tarara
+version: 1
+description: test
 
 compose-file: !include import_two_compose.yml
 

--- a/test/data/usage_scenarios/network_stress.yml
+++ b/test/data/usage_scenarios/network_stress.yml
@@ -2,6 +2,7 @@
 name: Test Stress
 author: Dan Mateas
 version: 1
+description: test
 
 networks:
   gmt-test-network:

--- a/test/data/usage_scenarios/port_bindings_stress.yml
+++ b/test/data/usage_scenarios/port_bindings_stress.yml
@@ -2,6 +2,7 @@
 name: Test Stress
 author: Dan Mateas
 version: 1
+description: test
 
 services:
   test-container:

--- a/test/data/usage_scenarios/setup_commands_multiple_stress.yml
+++ b/test/data/usage_scenarios/setup_commands_multiple_stress.yml
@@ -2,6 +2,7 @@
 name: Test Stress
 author: Dan Mateas
 version: 1
+description: test
 
 services:
   test-container:

--- a/test/data/usage_scenarios/setup_commands_stress.yml
+++ b/test/data/usage_scenarios/setup_commands_stress.yml
@@ -2,6 +2,7 @@
 name: Test Stress
 author: Dan Mateas
 version: 1
+description: test
 
 services:
   test-container:

--- a/test/data/usage_scenarios/volume_bindings_stress.yml
+++ b/test/data/usage_scenarios/volume_bindings_stress.yml
@@ -2,6 +2,7 @@
 name: Test Stress
 author: Dan Mateas
 version: 1
+description: test
 
 services:
   test-container:

--- a/test/stress-application/usage_scenario.yml
+++ b/test/stress-application/usage_scenario.yml
@@ -2,6 +2,7 @@
 name: Stress Container One Core 5 Seconds
 author: Arne Tarara
 version: 1
+description: test
 
 networks:
   network-for-pytests:


### PR DESCRIPTION
As mentioned in the changelog, I've added the description field to GMT as well.
I have a whole bunch of failing tests at the moment on the `blue-angel-compare` branch, but no longer any `Key error: 'description'` at least after this commit.

@dan-mm I don't know the details of `test/data/usage_scenarios/`, so I've added where it made sense to me. Could you please double check them?