### PR TITLE
Adds number of runs selected for comparison

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -56,7 +56,7 @@
                 <tr>
                     <th>Repositories (<i class="icon code github"></i> / <i class="icon code gitlab"></i> / <i class="icon code folder"></i> etc.)</th>
                     <th>Branch <i class="icon code branch"></i></th>
-                    <th><button id="compare-button" onclick="compareButton()" class="ui small button blue">Compare</button></th>
+                    <th><button id="compare-button" onclick="compareButton()" class="ui small button blue">Compare: 0 Run(s)</button></th>
                 </tr>
             </thead>
             <tbody></tbody>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -56,7 +56,7 @@
                 <tr>
                     <th>Repositories (<i class="icon code github"></i> / <i class="icon code gitlab"></i> / <i class="icon code folder"></i> etc.)</th>
                     <th>Branch <i class="icon code branch"></i></th>
-                    <th><button onclick="compareButton()" class="ui small button blue">Compare</button></th>
+                    <th><button id="compare-button" onclick="compareButton()" class="ui small button blue">Compare</button></th>
                 </tr>
             </thead>
             <tbody></tbody>

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -9,10 +9,8 @@ const compareButton = () => {
 }
 const updateCompareCount = () => {
     const countButton = document.getElementById('compare-button');
-    const checkedCount = document.querySelectorAll('input#chbx-proj:checked').length;
-    countButton.textContent = checkedCount === 0 ? "Compare" 
-                              : checkedCount === 1 ?`Compare: ${checkedCount} Run` 
-                              : `Compare: ${checkedCount} Runs`;
+    const checkedCount = document.querySelectorAll('input[name=chbx-proj]:checked').length;
+    countButton.textContent = `Compare: ${checkedCount} Run(s)`;
 }
 
 function allow_group_select_checkboxes(checkbox_wrapper_id){
@@ -124,14 +122,14 @@ function allow_group_select_checkboxes(checkbox_wrapper_id){
             <td class="td-index" title="${filename}">${filename}</td>
             <td class="td-index">${machine}</td>
             <td class="td-index" style="width: 120px"><span title="${last_run}">${dateToYMD(new Date(last_run))}</span></td>
-            <td><input type="checkbox" value="${id}" name="chbx-proj" id="chbx-proj" />&nbsp;</td>`;
+            <td><input type="checkbox" value="${id}" name="chbx-proj"/>&nbsp;</td>`;
 
     });
 
     $('.ui.accordion').accordion();
     $('#projects-table table').tablesort();
 
-    document.querySelectorAll('#chbx-proj').forEach((e) =>{
+    document.querySelectorAll('input[name=chbx-proj]').forEach((e) =>{
         e.addEventListener('change', updateCompareCount);
     })
   

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -7,6 +7,14 @@ const compareButton = () => {
     });
     window.location = link.substr(0,link.length-1);
 }
+const updateCompareCount = () => {
+    const countButton = document.getElementById('compare-button');
+    const checkedCount = document.querySelectorAll('input#chbx-proj:checked').length;
+    countButton.textContent = checkedCount === 0 ? "Compare" 
+                              : checkedCount === 1 ?`Compare: ${checkedCount} Run` 
+                              : `Compare: ${checkedCount} Runs`;
+}
+
 (async () => {
     const dateToYMD = (date) => {
         let day = date.getDate();
@@ -89,19 +97,23 @@ const compareButton = () => {
             <td class="td-index" title="${filename}">${filename}</td>
             <td class="td-index">${machine}</td>
             <td class="td-index" style="width: 120px"><span title="${last_run}">${dateToYMD(new Date(last_run))}</span></td>
-            <td><input type="checkbox" value="${id}" name="chbx-proj"/>&nbsp;</td>`;
+            <td><input type="checkbox" value="${id}" name="chbx-proj" id="chbx-proj" />&nbsp;</td>`;
 
     });
 
     $('.ui.accordion').accordion();
     $('#projects-table table').tablesort();
 
+    document.querySelectorAll('#chbx-proj').forEach((e) =>{
+        e.addEventListener('change', updateCompareCount);
+    })
 
     document.querySelectorAll('.toggle-checkbox').forEach((e) => {
         e.addEventListener('click', (e1) => {
             e1.currentTarget.closest('tr').querySelectorAll('td:first-child input').forEach((e2) => {
                 e2.checked = e1.currentTarget.checked
             })
+            updateCompareCount();
         })
     })
 


### PR DESCRIPTION
Adds number of runs selected for comparison. Fixes #274 

1. If there are no selected runs, the button will just say `Compare.`
![image](https://github.com/green-coding-berlin/green-metrics-tool/assets/40917760/57394a69-4f45-4920-89df-b8df4b35b55a)

2. If there is 1 run selected, the button says `Compare: 1 Run`
![image](https://github.com/green-coding-berlin/green-metrics-tool/assets/40917760/bc848c0b-c6d1-4101-beeb-7659b2fd171f)

3. Else it says `Compare: n Runs`
![image](https://github.com/green-coding-berlin/green-metrics-tool/assets/40917760/4a04fa0d-4194-4490-824a-7ea9ee1751d2)
