### PR TITLE
Macos utilization provider

### DIFF
--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -21,6 +21,12 @@ from db import DB
 
 METRIC_MAPPINGS = {
 
+    'cpu_utilization_macos_system': {
+        'clean_name': 'CPU Utilization',
+        'source': 'syscall',
+        'explanation': 'Duration of the phase measured by GMT through a macos syscall - host_statistics',
+    },
+
     'phase_time_syscall_system': {
         'clean_name': 'Phase Duration',
         'source': 'Syscall',

--- a/config.yml.example
+++ b/config.yml.example
@@ -92,6 +92,8 @@ measurement:
     #--- MacOS: On Mac you only need this provider. Please delete all others!
       powermetrics.provider.PowermetricsProvider:
         resolution: 100
+      cpu.utilization.macos.system.provider.CpuUtilizationMacosSystemProvider:
+        resolution: 100
     #--- Architecture - Common
     common:
     #--- Model based

--- a/metric_providers/cpu/utilization/macos/system/Makefile
+++ b/metric_providers/cpu/utilization/macos/system/Makefile
@@ -1,0 +1,4 @@
+CFLAGS = -o3 -Wall
+
+metric-provider-binary: source.c
+    gcc $< $(CFLAGS) -o $@

--- a/metric_providers/cpu/utilization/macos/system/provider.py
+++ b/metric_providers/cpu/utilization/macos/system/provider.py
@@ -1,0 +1,14 @@
+import os
+
+#pylint: disable=import-error
+from metric_providers.base import BaseMetricProvider
+
+class CpuUtilizationMacosSystemProvider(BaseMetricProvider):
+    def __init__(self, resolution):
+        super().__init__(
+            metric_name="cpu_utilization_macos_system",
+            metrics={'time': int, 'value': int},
+            resolution=resolution,
+            unit="Ratio",
+            current_dir=os.path.dirname(os.path.abspath(__file__)),
+        )

--- a/metric_providers/cpu/utilization/macos/system/source.c
+++ b/metric_providers/cpu/utilization/macos/system/source.c
@@ -1,0 +1,81 @@
+#include <stdio.h>
+#include <mach/mach.h>
+#include <mach/mach_host.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/time.h>
+
+static unsigned int msleep_time=1000;
+
+
+int main(int argc, char **argv) {
+
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    int c;
+
+    while ((c = getopt (argc, argv, "hi:d")) != -1) {
+        switch (c) {
+        case 'h':
+            printf("Usage: %s [-h] [-m]\n\n",argv[0]);
+            printf("\t-h      : displays this help\n");
+            printf("\t-i      : specifies the milliseconds sleep time that will be slept between measurements\n\n");
+            exit(0);
+        case 'i':
+            msleep_time = atoi(optarg);
+            break;
+        default:
+            fprintf(stderr,"Unknown option %c\n",c);
+            exit(-1);
+        }
+    }
+
+
+    host_cpu_load_info_data_t prevCpuLoad;
+    host_cpu_load_info_data_t currCpuLoad;
+    mach_msg_type_number_t count = HOST_CPU_LOAD_INFO_COUNT;
+    kern_return_t status;
+    struct timeval now;
+
+
+    status = host_statistics(mach_host_self(), HOST_CPU_LOAD_INFO, (host_info_t)&prevCpuLoad, &count);
+    if (status != KERN_SUCCESS) {
+        printf("Failed to retrieve CPU load information\n");
+        return 1;
+    }
+
+    while (1) {
+        status = host_statistics(mach_host_self(), HOST_CPU_LOAD_INFO, (host_info_t)&currCpuLoad, &count);
+        if (status != KERN_SUCCESS) {
+            printf("Failed to retrieve CPU load information\n");
+            return 1;
+        }
+
+        natural_t userDiff = currCpuLoad.cpu_ticks[CPU_STATE_USER] - prevCpuLoad.cpu_ticks[CPU_STATE_USER];
+        natural_t systemDiff = currCpuLoad.cpu_ticks[CPU_STATE_SYSTEM] - prevCpuLoad.cpu_ticks[CPU_STATE_SYSTEM];
+        natural_t idleDiff = currCpuLoad.cpu_ticks[CPU_STATE_IDLE] - prevCpuLoad.cpu_ticks[CPU_STATE_IDLE];
+        natural_t niceDiff = currCpuLoad.cpu_ticks[CPU_STATE_NICE] - prevCpuLoad.cpu_ticks[CPU_STATE_NICE];
+        unsigned long long computeDiff = userDiff + systemDiff + niceDiff;
+        unsigned long long totalDiff = userDiff + systemDiff + idleDiff + niceDiff;
+
+        if (totalDiff > 0) {
+            // float userPercent = (userDiff / totalDiff) * 100.0;
+            // float systemPercent = (systemDiff / totalDiff) * 100.0;
+            // float nicePercent = (niceDiff / totalDiff) * 100.0;
+            gettimeofday(&now, NULL); // will set now
+
+            printf("%llu%06llu %llu\n", (unsigned long long)now.tv_sec, (unsigned long long)now.tv_usec, (computeDiff*10000) / totalDiff ); // Deliberate integer conversion. Precision with 0.01% is good enough
+
+
+            // printf("User CPU utilization: %.2f%%\n", userPercent);
+            // printf("System CPU utilization: %.2f%%\n", systemPercent);
+            // printf("Nice CPU utilization: %.2f%%\n", nicePercent);
+        }
+
+        prevCpuLoad = currCpuLoad;
+
+        usleep(msleep_time*1000);
+    }
+
+    return 0;
+}

--- a/metric_providers/psu/energy/ac/sdia/machine/provider.py
+++ b/metric_providers/psu/energy/ac/sdia/machine/provider.py
@@ -32,12 +32,17 @@ class PsuEnergyAcSdiaMachineProvider(BaseMetricProvider):
 
     def read_metrics(self, project_id, containers):
 
-        if not os.path.isfile('/tmp/green-metrics-tool/cpu_utilization_procfs_system.log'):
-            raise RuntimeError('could not find the /tmp/green-metrics-tool/cpu_utilization_procfs_system.log file.\
-                Did you activate the CpuUtilizationProcfsSystemProvider in the config.yml too? \
-                This is required to run PsuEnergyAcSdiaMachineProvider')
+        filename = None
+        if os.path.isfile('/tmp/green-metrics-tool/cpu_utilization_procfs_system.log'):
+            filename = '/tmp/green-metrics-tool/cpu_utilization_procfs_system.log'
+        elif os.path.isfile('/tmp/green-metrics-tool/cpu_utilization_macos_system.log'):
+            filename = '/tmp/green-metrics-tool/cpu_utilization_macos_system.log'
+        else:
+            raise RuntimeError('could not find the /tmp/green-metrics-tool/cpu_utilization_procfs_system.log or /tmp/green-metrics-tool/cpu_utilization_macos_system.logfile. \
+                Did you activate the CpuUtilizationProcfsSystemProvider or CpuUtilizationMacosSystemProvider in the config.yml too? \
+                This is required to run PsuEnergyAcXgboostMachineProvider')
 
-        with open('/tmp/green-metrics-tool/cpu_utilization_procfs_system.log', 'r', encoding='utf-8') as file:
+        with open(filename, 'r', encoding='utf-8') as file:
             csv_data = file.read()
 
         # remove the last line from the string, as it may be broken due to the output buffering of the metrics reporter

--- a/metric_providers/psu/energy/ac/xgboost/machine/provider.py
+++ b/metric_providers/psu/energy/ac/xgboost/machine/provider.py
@@ -32,12 +32,17 @@ class PsuEnergyAcXgboostMachineProvider(BaseMetricProvider):
 
     def read_metrics(self, project_id, containers):
 
-        if not os.path.isfile('/tmp/green-metrics-tool/cpu_utilization_procfs_system.log'):
-            raise RuntimeError('could not find the /tmp/green-metrics-tool/cpu_utilization_procfs_system.log file. \
-                Did you activate the CpuUtilizationProcfsSystemProvider in the config.yml too? \
+        filename = None
+        if os.path.isfile('/tmp/green-metrics-tool/cpu_utilization_procfs_system.log'):
+            filename = '/tmp/green-metrics-tool/cpu_utilization_procfs_system.log'
+        elif os.path.isfile('/tmp/green-metrics-tool/cpu_utilization_macos_system.log'):
+            filename = '/tmp/green-metrics-tool/cpu_utilization_macos_system.log'
+        else:
+            raise RuntimeError('could not find the /tmp/green-metrics-tool/cpu_utilization_procfs_system.log or /tmp/green-metrics-tool/cpu_utilization_macos_system.logfile. \
+                Did you activate the CpuUtilizationProcfsSystemProvider or CpuUtilizationMacosSystemProvider in the config.yml too? \
                 This is required to run PsuEnergyAcXgboostMachineProvider')
 
-        with open('/tmp/green-metrics-tool/cpu_utilization_procfs_system.log', 'r', encoding='utf-8') as file:
+        with open(filename, 'r', encoding='utf-8') as file:
             csv_data = file.read()
         # remove the last line from the string, as it may be broken due to the output buffering of the metrics reporter
         csv_data = csv_data[:csv_data.rfind('\n')]

--- a/tools/phase_stats.py
+++ b/tools/phase_stats.py
@@ -79,6 +79,7 @@ def build_and_store_phase_stats(project_id):
             if metric in (
                 'lm_sensors_temperature_component',
                 'lm_sensors_fan_component',
+                'cpu_utilization_macos_system',
                 'cpu_utilization_procfs_system',
                 'cpu_utilization_cgroup_container',
                 'memory_total_cgroup_container',


### PR DESCRIPTION
It uses the `host_statistics` syscall in macos, same way as [htop does](https://github.com/htop-dev/htop/blob/main/darwin/DarwinMachine.c)

However sometimes I am getting 0 results for no reason ... 

2. The provider atm cannot be installed through the local scripts and even linux install will fail. We need to alter our directory structure to easily automate this.