### PR TITLE
Removing version requirement

### DIFF
--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -73,7 +73,6 @@ class SchemaChecker():
         usage_scenario_schema = Schema({
             "name": str,
             "author": str,
-            "version": Use(int),
             "description": str,
 
             Optional("networks"): {

--- a/runner.py
+++ b/runner.py
@@ -312,7 +312,6 @@ class Runner:
 
         print(TerminalColors.HEADER, '\nHaving Usage Scenario ', self._usage_scenario['name'], TerminalColors.ENDC)
         print('From: ', self._usage_scenario['author'])
-        print('Version ', self._usage_scenario['version'])
         print('Description: ', self._usage_scenario['description'], '\n')
 
         if self._allow_unsafe:


### PR DESCRIPTION
Currently we have the 'version' in the `usage_scenario.yml`.

I advocate here to remove this as it is just confusing because it conflicts with the `docker-compose.yml` *version* which actually has a meaning.

The idea of having a *version* is that one can versionate the `usage_scenario.yml`. However the way we actually use it we never advance this number and since we now merge with a compose file this is more confusing than helpful and anyway overwritten by the `docker-compose.yml` in the merge process ...


@dan-mm ok? Tests should not be concerned I guess?
@ribalba remarks?