### PR TITLE
First draft for fix regarding docker context subdir fix

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -66,7 +66,7 @@ def join_path_and_file(path, file):
         raise ValueError(f"{file} not in {path}")
 
     # To double check we also check if it is in the files allow list
-    folder_content = [str(item) for item in Path(path).rglob("*") if item.is_file()]
+    folder_content = [str(item) for item in Path(path).rglob("*")]
     if filename not in folder_content:
         raise ValueError(f"{file} not in {path}")
 


### PR DESCRIPTION
@ribalba For a client the issue occured that the follow `compose.yml` file lead to an error:

```
---
#name: Stress Container One Core 5 Seconds
services:
  gcb-alpine-stress:
    container_name: gcb-alpine-stress
    build:
      context: ./subdir
      dockerfile: ./Dockerfile
```

This is a modified version of the [Stress example](https://github.com/green-coding-berlin/example-applications/tree/main/stress) where I moved the`Dockerfile` into a subfolder.

The code in the `join_path_and_file` function is only designed to accept files. But in order to check the context, which is triggered here: https://github.com/green-coding-berlin/green-metrics-tool/blob/4753c0e89dca679d7f08abbcb2214e30dfa48844/runner.py#L273
actually a folder is supplied.

This leads to an unwanted error. The error does appear when we use `.` as a context as this is shortcutted earlier: https://github.com/green-coding-berlin/green-metrics-tool/blob/4753c0e89dca679d7f08abbcb2214e30dfa48844/runner.py#L62

The proposed fix removed the filter for `is_file`. My question: Is that safe and also cross-platform safe? Under my linux box the iterator does not include `..` and `.` directories, but only the real contents. Unclear how symlinks might appear hear ... the `Path(path)` call should resolve them if I understand correctly?