### PR TITLE
tmpfs can now be set in install script

### DIFF
--- a/.github/actions/gmt-pytest/action.yml
+++ b/.github/actions/gmt-pytest/action.yml
@@ -41,7 +41,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.gmt-directory }}
       run: |
-        ./install_linux.sh -p testpw -a http://api.green-coding.internal:9142 -m http://metrics.green-coding.internal:9142 -n -w
+        ./install_linux.sh -p testpw -a http://api.green-coding.internal:9142 -m http://metrics.green-coding.internal:9142 -n -t -w
         python3 disable_metric_providers.py ${{ inputs.metrics-to-turn-off }}
         cd test && python3 setup-test-env.py --no-docker-build
 

--- a/.github/actions/gmt-pytest/action.yml
+++ b/.github/actions/gmt-pytest/action.yml
@@ -41,7 +41,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.gmt-directory }}
       run: |
-        ./install_linux.sh -p testpw -a http://api.green-coding.internal:9142 -m http://metrics.green-coding.internal:9142 -n
+        ./install_linux.sh -p testpw -a http://api.green-coding.internal:9142 -m http://metrics.green-coding.internal:9142 -n -w
         python3 disable_metric_providers.py ${{ inputs.metrics-to-turn-off }}
         cd test && python3 setup-test-env.py --no-docker-build
 

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -15,8 +15,9 @@ api_url=''
 metrics_url=''
 no_build=false
 no_hosts=false
+ask_tmpfs=true
 
-while getopts "p:a:m:n:h" o; do
+while getopts "p:a:m:n:h:t" o; do
     case "$o" in
         p)
             db_pw=${OPTARG}
@@ -33,6 +34,10 @@ while getopts "p:a:m:n:h" o; do
         h)
             no_hosts=true
             ;;
+        t)
+            ask_tmpfs=false
+            ;;
+
     esac
 done
 
@@ -48,6 +53,14 @@ fi
 
 if [[ -z "$db_pw" ]] ; then
     read -sp "Please enter the new password to be set for the PostgreSQL DB: " db_pw
+fi
+
+if [[ $ask_tmpfs == true ]] ; then
+    read -p "We strongly recommend mounting /tmp on a tmpfs. Do you want to do that? (y/N)" tmpfs
+    if [[ "$tmpfs" == "Y" || "$tmpfs" == "y" ]] ; then
+        sudo systemctl enable /usr/share/systemd/tmp.mount
+        print "OK"
+    fi
 fi
 
 print_message "Clearing old api.conf and frontend.conf files"

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -58,7 +58,11 @@ fi
 if [[ $ask_tmpfs == true ]] ; then
     read -p "We strongly recommend mounting /tmp on a tmpfs. Do you want to do that? (y/N)" tmpfs
     if [[ "$tmpfs" == "Y" || "$tmpfs" == "y" ]] ; then
-        sudo systemctl enable /usr/share/systemd/tmp.mount
+        if lsb_release -is | grep -q "Fedora"; then
+            sudo systemctl unmask --now tmp.mount
+        else
+            sudo systemctl enable /usr/share/systemd/tmp.mount
+        fi
     fi
 fi
 

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -16,9 +16,8 @@ metrics_url=''
 no_build=false
 no_hosts=false
 ask_tmpfs=true
-workflow_automation=false
 
-while getopts "p:a:m:nhtw" o; do
+while getopts "p:a:m:nht" o; do
     case "$o" in
         p)
             db_pw=${OPTARG}
@@ -37,9 +36,6 @@ while getopts "p:a:m:nhtw" o; do
             ;;
         t)
             ask_tmpfs=false
-            ;;
-        w)
-            workflow_automation=true
             ;;
 
     esac
@@ -60,11 +56,7 @@ if [[ -z "$db_pw" ]] ; then
 fi
 
 if [[ $ask_tmpfs == true ]] ; then
-    if [[ $workflow_automation == false ]] ; then
-        read -p "We strongly recommend mounting /tmp on a tmpfs. Do you want to do that? (y/N)" tmpfs
-    else 
-        tmpfs="y"
-    fi
+    read -p "We strongly recommend mounting /tmp on a tmpfs. Do you want to do that? (y/N)" tmpfs
     if [[ "$tmpfs" == "Y" || "$tmpfs" == "y" ]] ; then
         sudo systemctl enable /usr/share/systemd/tmp.mount
     fi

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -16,8 +16,9 @@ metrics_url=''
 no_build=false
 no_hosts=false
 ask_tmpfs=true
+workflow_automation=false
 
-while getopts "p:a:m:n:h:t" o; do
+while getopts "p:a:m:nhtw" o; do
     case "$o" in
         p)
             db_pw=${OPTARG}
@@ -36,6 +37,9 @@ while getopts "p:a:m:n:h:t" o; do
             ;;
         t)
             ask_tmpfs=false
+            ;;
+        w)
+            workflow_automation=true
             ;;
 
     esac
@@ -56,7 +60,11 @@ if [[ -z "$db_pw" ]] ; then
 fi
 
 if [[ $ask_tmpfs == true ]] ; then
-    read -p "We strongly recommend mounting /tmp on a tmpfs. Do you want to do that? (y/N)" tmpfs
+    if [[ $workflow_automation == false ]] ; then
+        read -p "We strongly recommend mounting /tmp on a tmpfs. Do you want to do that? (y/N)" tmpfs
+    else 
+        tmpfs="y"
+    fi
     if [[ "$tmpfs" == "Y" || "$tmpfs" == "y" ]] ; then
         sudo systemctl enable /usr/share/systemd/tmp.mount
     fi

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -59,7 +59,6 @@ if [[ $ask_tmpfs == true ]] ; then
     read -p "We strongly recommend mounting /tmp on a tmpfs. Do you want to do that? (y/N)" tmpfs
     if [[ "$tmpfs" == "Y" || "$tmpfs" == "y" ]] ; then
         sudo systemctl enable /usr/share/systemd/tmp.mount
-        print "OK"
     fi
 fi
 
@@ -160,3 +159,4 @@ fi
 
 echo ""
 echo -e "${GREEN}Successfully installed Green Metrics Tool!${NC}"
+echo -e "${GREEN}If you have newly requested to mount /tmp as tmpfs please reboot your system now.${NC}"


### PR DESCRIPTION
@dan-mm I added a functionality so that the system will be put on a `tmpfs` for the `/tmp` directory in the install script.

This parameter triggers an input dialog.

Could you please adapt tests and pipelines so that the new code will run and then merge it?