### PR TITLE
No notify admin for own project add

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -374,11 +374,15 @@ async def post_project_add(project: Project):
         """
     params = (project.url, project.name, project.email, project.branch, project.filename)
     project_id = DB().fetch_one(query, params=params)[0]
+
     # This order as selected on purpose. If the admin mail fails, we currently do
     # not want the job to be queued, as we want to monitor every project execution manually
-    email_helpers.send_admin_email(
-        f"New project added from Web Interface: {project.name}", project
-    )  # notify admin of new project
+    config = GlobalConfig().config
+    if (config['admin']['notify_admin_for_own_project_add'] or config['admin']['email'] != project.email):
+        email_helpers.send_admin_email(
+            f"New project added from Web Interface: {project.name}", project
+        )  # notify admin of new project
+
     jobs.insert_job('project', project_id, project.machine_id)
 
     return ORJSONResponse({'success': True}, status_code=202)

--- a/config.yml.example
+++ b/config.yml.example
@@ -20,6 +20,11 @@ admin:
   email: myemail@dev.local
   # no_emails: True will suppress all emails. Helpful in development servers
   no_emails: True
+  # notifiy_admin_for_own_project_add: False will suppress an email if a project is added with the
+  # same email address as the admin.
+  # If no_emails is set to True, this will have no effect
+  notify_admin_for_own_project_add: False
+
 
 cluster:
   api_url: __API_URL__


### PR DESCRIPTION
GMT now allows to suppress success emails for adding projects in case the action was done by the admin