### PR TITLE
Sanitize CI

### DIFF
--- a/.github/workflows/tests-vm-pr.yml
+++ b/.github/workflows/tests-vm-pr.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: 'true'
 
       - name: Eco CI Energy Estimation - Initialize
-        uses: green-coding-berlin/eco-ci-energy-estimation@v1
+        uses: green-coding-berlin/eco-ci-energy-estimation@v2
         with:
           task: start-measurement
 

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -241,10 +241,10 @@ const displayCITable = (runs, url_params) => {
 
         var run_link = ''
         if(source == 'github') {
-            run_link = `https://github.com/${url_params.get('repo')}/actions/runs/${run_id}`;
+            run_link = `https://github.com/${escapeString(url_params.get('repo'))}/actions/runs/${run_id}`;
         }
         else if (source == 'gitlab') {
-            run_link = `https://gitlab.com/${url_params.get('repo')}/-/pipelines/${run_id}`
+            run_link = `https://gitlab.com/${escapeString(url_params.get('repo'))}/-/pipelines/${run_id}`
         }
 
         const run_link_node = `<a href="${run_link}" target="_blank">${run_id}</a>`
@@ -254,13 +254,13 @@ const displayCITable = (runs, url_params) => {
         const label = el[4]
         const duration = el[7]
 
-        li_node.innerHTML = `<td class="td-index">${sanitize(value)}</td>\
-                            <td class="td-index">${sanitize(label)}</td>\
-                            <td class="td-index">${sanitize(run_link_node)}</td>\
-                            <td class="td-index"><span title="${sanitize(created_at)}">${dateToYMD(new Date(sanitize(created_at)))}</span></td>\
-                            <td class="td-index" ${sanitize(tooltip)}>${sanitize(short_hash)}</td>\
-                            <td class="td-index">${sanitize(cpu)}</td>\
-                            <td class="td-index">${sanitize(duration)} seconds</td>`;
+        li_node.innerHTML = `<td class="td-index">${escapeString(value)}</td>\
+                            <td class="td-index">${escapeString(label)}</td>\
+                            <td class="td-index">${escapeString(run_link_node)}</td>\
+                            <td class="td-index"><span title="${escapeString(created_at)}">${dateToYMD(new Date(escapeString(created_at)))}</span></td>\
+                            <td class="td-index" ${escapeString(tooltip)}>${escapeString(short_hash)}</td>\
+                            <td class="td-index">${escapeString(cpu)}</td>\
+                            <td class="td-index">${escapeString(duration)} seconds</td>`;
         document.querySelector("#ci-table").appendChild(li_node);
     });
     $('table').tablesort();
@@ -318,16 +318,16 @@ $(document).ready((e) => {
         let repo_link = ''
 
         if(badges_data.data[0][8] == 'github') {
-            repo_link = `https://github.com/${sanitize(url_params.get('repo'))}`;
+            repo_link = `https://github.com/${escapeString(url_params.get('repo'))}`;
         }
         else if(badges_data.data[0][8] == 'gitlab') {
-            repo_link = `https://gitlab.com/${sanitize(url_params.get('repo'))}`;
+            repo_link = `https://gitlab.com/${escapeString(url_params.get('repo'))}`;
         }
         //${repo_link}
-        const repo_link_node = `<a href="${repo_link}" target="_blank">${url_params.get('repo')}</a>`
+        const repo_link_node = `<a href="${repo_link}" target="_blank">${escapeString(url_params.get('repo'))}</a>`
         document.querySelector('#ci-data').insertAdjacentHTML('afterbegin', `<tr><td><strong>Repository:</strong></td><td>${repo_link_node}</td></tr>`)
-        document.querySelector('#ci-data').insertAdjacentHTML('afterbegin', `<tr><td><strong>Branch:</strong></td><td>${sanitize(url_params.get('branch'))}</td></tr>`)
-        document.querySelector('#ci-data').insertAdjacentHTML('afterbegin', `<tr><td><strong>Workflow:</strong></td><td>${sanitize(url_params.get('workflow'))}</td></tr>`)
+        document.querySelector('#ci-data').insertAdjacentHTML('afterbegin', `<tr><td><strong>Branch:</strong></td><td>${escapeString(url_params.get('branch'))}</td></tr>`)
+        document.querySelector('#ci-data').insertAdjacentHTML('afterbegin', `<tr><td><strong>Workflow:</strong></td><td>${escapeString(url_params.get('workflow'))}</td></tr>`)
         
         displayCITable(badges_data.data, url_params);
         chart_instance = displayGraph(badges_data.data)

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -318,10 +318,10 @@ $(document).ready((e) => {
         let repo_link = ''
 
         if(badges_data.data[0][8] == 'github') {
-            repo_link = `https://github.com/${url_params.get('repo')}`;
+            repo_link = `https://github.com/${sanitize(url_params.get('repo'))}`;
         }
         else if(badges_data.data[0][8] == 'gitlab') {
-            repo_link = `https://gitlab.com/${url_params.get('repo')}`;
+            repo_link = `https://gitlab.com/${sanitize(url_params.get('repo'))}`;
         }
         //${repo_link}
         const repo_link_node = `<a href="${repo_link}" target="_blank">${url_params.get('repo')}</a>`

--- a/frontend/js/ci.js
+++ b/frontend/js/ci.js
@@ -254,13 +254,13 @@ const displayCITable = (runs, url_params) => {
         const label = el[4]
         const duration = el[7]
 
-        li_node.innerHTML = `<td class="td-index">${value}</td>\
-                            <td class="td-index">${label}</td>\
-                            <td class="td-index">${run_link_node}</td>\
-                            <td class="td-index"><span title="${created_at}">${dateToYMD(new Date(created_at))}</span></td>\
-                            <td class="td-index" ${tooltip}>${short_hash}</td>\
-                            <td class="td-index">${cpu}</td>\
-                            <td class="td-index">${duration} seconds</td>`;
+        li_node.innerHTML = `<td class="td-index">${sanitize(value)}</td>\
+                            <td class="td-index">${sanitize(label)}</td>\
+                            <td class="td-index">${sanitize(run_link_node)}</td>\
+                            <td class="td-index"><span title="${sanitize(created_at)}">${dateToYMD(new Date(sanitize(created_at)))}</span></td>\
+                            <td class="td-index" ${sanitize(tooltip)}>${sanitize(short_hash)}</td>\
+                            <td class="td-index">${sanitize(cpu)}</td>\
+                            <td class="td-index">${sanitize(duration)} seconds</td>`;
         document.querySelector("#ci-table").appendChild(li_node);
     });
     $('table').tablesort();
@@ -326,8 +326,8 @@ $(document).ready((e) => {
         //${repo_link}
         const repo_link_node = `<a href="${repo_link}" target="_blank">${url_params.get('repo')}</a>`
         document.querySelector('#ci-data').insertAdjacentHTML('afterbegin', `<tr><td><strong>Repository:</strong></td><td>${repo_link_node}</td></tr>`)
-        document.querySelector('#ci-data').insertAdjacentHTML('afterbegin', `<tr><td><strong>Branch:</strong></td><td>${url_params.get('branch')}</td></tr>`)
-        document.querySelector('#ci-data').insertAdjacentHTML('afterbegin', `<tr><td><strong>Workflow:</strong></td><td>${url_params.get('workflow')}</td></tr>`)
+        document.querySelector('#ci-data').insertAdjacentHTML('afterbegin', `<tr><td><strong>Branch:</strong></td><td>${sanitize(url_params.get('branch'))}</td></tr>`)
+        document.querySelector('#ci-data').insertAdjacentHTML('afterbegin', `<tr><td><strong>Workflow:</strong></td><td>${sanitize(url_params.get('workflow'))}</td></tr>`)
         
         displayCITable(badges_data.data, url_params);
         chart_instance = displayGraph(badges_data.data)

--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -32,7 +32,7 @@ class GMTMenu extends HTMLElement {
 }
 customElements.define('gmt-menu', GMTMenu);
 
-function sanitize(string) {
+function escapeString(string) {
     const map = {
       '&': '&amp;',
       '<': '&lt;',

--- a/frontend/js/helpers/main.js
+++ b/frontend/js/helpers/main.js
@@ -32,6 +32,18 @@ class GMTMenu extends HTMLElement {
 }
 customElements.define('gmt-menu', GMTMenu);
 
+function sanitize(string) {
+    const map = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#x27;'
+    };
+    const reg = /[&<>"']/ig;
+    return string.replace(reg, (match) => map[match]);
+  }
+
 const replaceRepoIcon = (uri) => {
     if (uri.startsWith("https://www.github.com") || uri.startsWith("https://github.com")) {
         uri = uri.replace("https://www.github.com", '<i class="icon github"></i>');

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -5,7 +5,7 @@ const compareButton = () => {
     checkedBoxes.forEach(checkbox => {
         link = `${link}${checkbox.value},`;
     });
-    window.location = link.substr(0,link.length-1);
+    window.location = encodeURIComponent(link.substr(0, link.length - 1));
 }
 const updateCompareCount = () => {
     const countButton = document.getElementById('compare-button');


### PR DESCRIPTION
Code scanning alerts do have a # but they can't be referenced if they are not issues, so here's what this fixes:

- Alerts 1-6 : Icon replacements. We don't open or visit the URL, and the matching is for the beginning of the URL. I would dismiss these alerts
- Alert 7:  wrap in `encodeURIComponent()`
- Alert 8,9,10,11: wrap in new `sanitize()` js function in `helpers/main.js` that escapes < > & ' "