### PR TITLE
Postgres 15

### DIFF
--- a/docker/compose.yml.example
+++ b/docker/compose.yml.example
@@ -1,6 +1,6 @@
 services:
   green-coding-postgres:
-    image: postgres
+    image: postgres:15
     shm_size: 256MB
     container_name: green-coding-postgres-container
     restart: always


### PR DESCRIPTION
We are using Postgres 15 now.

Please see https://docs.green-coding.berlin/docs/installation/updating/#update-postgresql for migrating