### PR TITLE
Gunicorn now logs access to stdout

### DIFF
--- a/docker/Dockerfile-gunicorn
+++ b/docker/Dockerfile-gunicorn
@@ -11,4 +11,4 @@ RUN pip3 install -r requirements.txt
 
 RUN rm -rf /var/lib/apt/lists/*
 
-ENTRYPOINT ["/bin/gunicorn", "--workers=2", "--log-file=-", "--worker-tmp-dir=/dev/shm", "--threads=4", "--worker-class=gthread",  "--bind", "unix:/tmp/green-coding-api.sock", "-m", "007", "--user", "www-data", "--chdir", "/var/www/green-metrics-tool/api", "-k", "uvicorn.workers.UvicornWorker", "api:app"]
+ENTRYPOINT ["/bin/gunicorn", "--workers=2", "--access-logfile=-", "--error-logfile=-", "--worker-tmp-dir=/dev/shm", "--threads=4", "--worker-class=gthread",  "--bind", "unix:/tmp/green-coding-api.sock", "-m", "007", "--user", "www-data", "--chdir", "/var/www/green-metrics-tool/api", "-k", "uvicorn.workers.UvicornWorker", "api:app"]


### PR DESCRIPTION
Gunicorn now logs access logs to STDOUT.

This means we can now `print()` in the API and the logs will show up in the container logs.