### PR TITLE
Enables empty services in the usage_scenario

### DIFF
--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -80,7 +80,7 @@ class SchemaChecker():
             },
 
             Optional("services"): {
-                Use(self.contains_no_invalid_chars): Or (None, {
+                Use(self.contains_no_invalid_chars): {
                     Optional("type"): Use(self.valid_service_types),
                     Optional("image"): str,
                     Optional("networks"): self.single_or_list(Use(self.contains_no_invalid_chars)),
@@ -90,7 +90,7 @@ class SchemaChecker():
                     Optional("volumes"): self.single_or_list(str),
                     Optional("folder-destination"):str,
                     Optional("cmd"): str,
-                }, ignore_extra_keys=True)
+                },
             },
 
             "flow": [{

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -80,7 +80,7 @@ class SchemaChecker():
             },
 
             Optional("services"): {
-                Use(self.contains_no_invalid_chars): {
+                Use(self.contains_no_invalid_chars): Or (None, {
                     Optional("type"): Use(self.valid_service_types),
                     Optional("image"): str,
                     Optional("networks"): self.single_or_list(Use(self.contains_no_invalid_chars)),
@@ -90,7 +90,7 @@ class SchemaChecker():
                     Optional("volumes"): self.single_or_list(str),
                     Optional("folder-destination"):str,
                     Optional("cmd"): str,
-                }
+                }, ignore_extra_keys=True)
             },
 
             "flow": [{

--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -90,7 +90,7 @@ class SchemaChecker():
                     Optional("volumes"): self.single_or_list(str),
                     Optional("folder-destination"):str,
                     Optional("cmd"): str,
-                },
+                }
             },
 
             "flow": [{

--- a/runner.py
+++ b/runner.py
@@ -337,6 +337,15 @@ class Runner:
                 del yml_obj['compose-file']
 
             yml_obj.update(new_dict)
+
+            # If a service is defined as None we remove it. This is so we can have a compose file that starts
+            # all the various services but we can disable them in the usage_scenario. This is quite useful when
+            # creating benchmarking scripts and you want to have all options in the compose but not in each benchmark.
+            # The cleaner way would be to handle an empty service key throughout the code but would make it quite messy
+            # so we chose to remove it right at the start.
+            for key in [sname for sname, content in yml_obj['services'].items() if content is None]:
+                del yml_obj['services'][key]
+
             self._usage_scenario = yml_obj
 
     def initial_parse(self):


### PR DESCRIPTION
This enables you to have a compose file in which you specify all services that might be used at some stage. You can disabale a service in your usage_scenario by setting it to None. So let's say you have two databases defined in your compose.yml `db1` and `db2`.  You can only use one by adding to your usage file but still include the compose.
```
services:
    db2:
```