### PR TITLE
SCI metric

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -8,6 +8,7 @@ import faulthandler
 import sys
 import os
 
+from xml.sax.saxutils import escape as xml_escape
 from fastapi import FastAPI, Request, Response, status
 from fastapi.responses import ORJSONResponse
 from fastapi.encoders import jsonable_encoder
@@ -30,7 +31,6 @@ import anybadge
 from api_helpers import (add_phase_stats_statistics, determine_comparison_case,
                          sanitize, get_phase_stats, get_phase_stats_object,
                          is_valid_uuid, rescale_energy_value)
-
 
 # It seems like FastAPI already enables faulthandler as it shows stacktrace on SEGFAULT
 # Is the redundant call problematic
@@ -335,8 +335,8 @@ async def get_badge_single(project_id: str, metric: str = 'ml-estimated'):
         badge_value= f"{energy_value:.2f} {energy_unit} {via}"
 
     badge = anybadge.Badge(
-        label=label,
-        value=badge_value,
+        label=xml_escape(label),
+        value=xml_escape(badge_value),
         num_value_padding_chars=1,
         default_color='cornflowerblue')
     return Response(content=str(badge), media_type="image/svg+xml")
@@ -538,7 +538,7 @@ async def get_ci_badge_get(repo: str, branch: str, workflow:str):
 
     badge = anybadge.Badge(
         label='Energy Used',
-        value=badge_value,
+        value=xml_escape(badge_value),
         num_value_padding_chars=1,
         default_color='green')
     return Response(content=str(badge), media_type="image/svg+xml")

--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -234,17 +234,21 @@ METRIC_MAPPINGS = {
 
 def rescale_energy_value(value, unit):
     # We only expect values to be mJ for energy!
-    if unit != 'mJ':
+    if unit in ['mJ', 'ug'] or unit.startswith('ugCO2e/'):
+        unit_type = unit[1:]
+
+        energy_rescaled = [value, unit]
+
+        # pylint: disable=multiple-statements
+        if value > 1_000_000_000: energy_rescaled = [value/(10**12), f"G{unit_type}"]
+        elif value > 1_000_000_000: energy_rescaled = [value/(10**9), f"M{unit_type}"]
+        elif value > 1_000_000: energy_rescaled = [value/(10**6), f"k{unit_type}"]
+        elif value > 1_000: energy_rescaled = [value/(10**3), f"{unit_type}"]
+        elif value < 0.001: energy_rescaled = [value*(10**3), f"n{unit_type}"]
+
+    else:
         raise RuntimeError('Unexpected unit occured for energy rescaling: ', unit)
 
-    energy_rescaled = [value, unit]
-
-    # pylint: disable=multiple-statements
-    if value > 1_000_000_000: energy_rescaled = [value/(10**12), 'GJ']
-    elif value > 1_000_000_000: energy_rescaled = [value/(10**9), 'MJ']
-    elif value > 1_000_000: energy_rescaled = [value/(10**6), 'kJ']
-    elif value > 1_000: energy_rescaled = [value/(10**3), 'J']
-    elif value < 0.001: energy_rescaled = [value*(10**3), 'nJ']
 
     return energy_rescaled
 

--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -21,6 +21,17 @@ from db import DB
 
 METRIC_MAPPINGS = {
 
+
+    'embodied_carbon_share_machine': {
+        'clean_name': 'Embodied Carbon',
+        'source': 'formula',
+        'explanation': 'Embodied carbon attributed by time share of the life-span and total embodied carbon',
+    },
+    'software_carbon_intensity_global': {
+        'clean_name': 'SCI',
+        'source': 'formula',
+        'explanation': 'SCI metric by the Green Software Foundation',
+    },
     'phase_time_syscall_system': {
         'clean_name': 'Phase Duration',
         'source': 'Syscall',

--- a/config.yml.example
+++ b/config.yml.example
@@ -123,7 +123,7 @@ measurement:
   #--- END
 
 
-gsf-sci:
+sci:
     # https://github.com/Green-Software-Foundation/sci/blob/main/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
 
     # The values specific to the machine will be set here. The values that are specific to the

--- a/config.yml.example
+++ b/config.yml.example
@@ -27,6 +27,7 @@ admin:
   notify_admin_for_own_project_ready: False
 
 
+
 cluster:
   api_url: __API_URL__
   metrics_url: __METRICS_URL__
@@ -120,3 +121,31 @@ measurement:
 #        HW_MemAmountGB: 16
 #        Hardware_Availability_Year: 2011
   #--- END
+
+
+gsf-sci:
+    # https://github.com/Green-Software-Foundation/sci/blob/main/Software_Carbon_Intensity/Software_Carbon_Intensity_Specification.md
+
+    # The values specific to the machine will be set here. The values that are specific to the
+    # software, like R – Functional unit, will be set in the usage_scenario.yml
+
+    # EL Expected Lifespan; the anticipated time that the equipment will be installed. Value is in years
+    # The number 3.5 comes from a typical developer machine (Apple Macbook 16" 2023 - https://dataviz.boavizta.org/manufacturerdata?lifetime=3.5&name=14-inch%20MacBook%20Pro%20with%2064GB)
+    EL: 3.5
+    # RS Resource-share; the share of the total available resources of the hardware reserved for use by the software.
+    # This ratio is typically 1 with the Green Metrics Tool unless you use a custom distributed orchestrator
+    RS: 1
+    # TE Total Embodied Emissions; the sum of Life Cycle Assessment (LCA) emissions for all hardware components.
+    # Value is in gCO2eq
+    # The value has to be identified from vendor datasheets. Here are some example sources:
+    # https://dataviz.boavizta.org/manufacturerdata
+    # https://tco.exploresurface.com/sustainability/calculator
+    # https://www.delltechnologies.com/asset/en-us/products/servers/technical-support/Full_LCA_Dell_R740.pdf
+    # The default is the value for a developer machine (Apple Macbook 16" 2023 - https://dataviz.boavizta.org/manufacturerdata?lifetime=3.5&name=14-inch%20MacBook%20Pro%20with%2064GB)
+    TE: 194000
+    # I is the Carbon Intensity at the location of this machine
+    # The value can either be a number in gCO2e/kWh or a carbon intensity provider that fetches this number dynamically
+    # https://docs.green-coding.berlin/docs/measuring/carbon-intensity-providers/carbon-intensity-providers-overview/
+    # For fixed values get the number from https://ember-climate.org/insights/research/global-electricity-review-2022/
+    # The number 475 that comes as default is for Germany from 2022
+    I: 475

--- a/frontend/css/green-coding.css
+++ b/frontend/css/green-coding.css
@@ -160,6 +160,7 @@ a,
     text-overflow: ellipsis;
     overflow-wrap: normal;
     overflow: hidden;
+    white-space: nowrap;
 }
 
 .si-unit {

--- a/frontend/js/helpers/metric-boxes.js
+++ b/frontend/js/helpers/metric-boxes.js
@@ -141,7 +141,7 @@ class PhaseMetrics extends HTMLElement {
             </div>
             <div class="ui card software-carbon-intensity">
                 <div class="ui content">
-                    <div class="ui top black attached label overflow-ellipsis">Green Software Foundation SCI</sub><span class="si-unit"></span></div>
+                    <div class="ui top black attached label overflow-ellipsis">SCI</sub> <span class="si-unit"></span></div>
                     <div class="description">
                         <div class="ui fluid mini statistic">
                             <div class="value">

--- a/frontend/js/helpers/metric-boxes.js
+++ b/frontend/js/helpers/metric-boxes.js
@@ -139,6 +139,25 @@ class PhaseMetrics extends HTMLElement {
                     </div>
                 </div>
             </div>
+            <div class="ui card software-carbon-intensity">
+                <div class="ui content">
+                    <div class="ui top black attached label overflow-ellipsis">Green Software Foundation SCI</sub><span class="si-unit"></span></div>
+                    <div class="description">
+                        <div class="ui fluid mini statistic">
+                            <div class="value">
+                                <i class="burn icon"></i> <span>N/A</span>
+                            </div>
+                        </div>
+                        <div class="ui bottom right attached label icon" data-position="bottom right" data-inverted="" data-tooltip="SCI by the Green Software Foundation">
+                            <u><a href="https://sci-guide.greensoftware.foundation/">via Formula</a></u>
+                            <i class="question circle icon"></i>
+                        </div>
+                        <div class="ui bottom left attached label">
+                            <span class="metric-type"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div><!-- end ui three cards stackable -->
         <br>
         <div class="ui accordion">
@@ -309,6 +328,10 @@ const updateKeyMetric = (phase, metric_name, clean_name, detail_name, value, std
         selector = '.phase-duration';
     } else if(metric == 'network_co2_formula_global') {
         selector = '.network-co2';
+    } else if(metric == 'embodied_carbon_share_machine') {
+        selector = '.embodied-carbon';
+    } else if(metric == 'software_carbon_intensity_global') {
+        selector = '.software-carbon-intensity';
     } else if(metric.match(/^.*_power_.*_machine$/) !== null) {
         selector = '.machine-power';
     } else if(metric.match(/^.*_co2_.*_machine$/) !== null) {

--- a/frontend/js/helpers/metric-boxes.js
+++ b/frontend/js/helpers/metric-boxes.js
@@ -344,7 +344,7 @@ const updateKeyMetric = (phase, metric_name, clean_name, detail_name, value, std
     document.querySelector(`div.tab[data-tab='${phase}'] ${selector} .value span`).innerText = `${(value)} ${std_dev_text}`
     document.querySelector(`div.tab[data-tab='${phase}'] ${selector} .si-unit`).innerText = `[${unit}]`
     if(std_dev_text != '') document.querySelector(`div.tab[data-tab='${phase}'] ${selector} .metric-type`).innerText = `(AVG + STD.DEV)`;
-    else if(value.indexOf('%') !== -1) document.querySelector(`div.tab[data-tab='${phase}'] ${selector} .metric-type`).innerText = `(Diff. in %)`;
+    else if(String(value).indexOf('%') !== -1) document.querySelector(`div.tab[data-tab='${phase}'] ${selector} .metric-type`).innerText = `(Diff. in %)`;
 
     node = document.querySelector(`div.tab[data-tab='${phase}'] ${selector} .source`)
     if (node !== null) node.innerText = source // not every key metric shall have a custom detail_name

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -71,7 +71,7 @@
                             <div class="inline field">
                                 <span class="energy-badge-container" data-metric="ml-estimated"></span>
                                 <div class="ui left pointing blue basic label">
-                                    XGBoost estimated AC energy
+                                    XGBoost estimated AC energy (Runtime)
                                 </div>
                                 <a href="#" class="copy-badge"><i class="copy icon"></i></a>
                             </div>
@@ -79,7 +79,7 @@
                             <div class="inline field">
                                 <span class="energy-badge-container" data-metric="RAPL"></span>
                                 <div class="ui left pointing blue basic label">
-                                    RAPL component energy
+                                    RAPL component energy (Runtime)
                                 </div>
                                 <a href="#" class="copy-badge"><i class="copy icon"></i></a>
                             </div>
@@ -87,7 +87,15 @@
                             <div class="inline field">
                                 <span class="energy-badge-container" data-metric="AC"></span>
                                 <div class="ui left pointing blue basic label">
-                                    Measured AC energy
+                                    Measured AC energy (Runtime)
+                                </div>
+                                <a href="#" class="copy-badge"><i class="copy icon"></i></a>
+                            </div>
+                            <div class="ui divider"></div>
+                            <div class="inline field">
+                                <span class="energy-badge-container" data-metric="SCI"></span>
+                                <div class="ui left pointing blue basic label">
+                                    SCI (Runtime)
                                 </div>
                                 <a href="#" class="copy-badge"><i class="copy icon"></i></a>
                             </div>

--- a/metric_providers/base.py
+++ b/metric_providers/base.py
@@ -72,7 +72,7 @@ class BaseMetricProvider:
         elif self._metrics.get('container_id') is not None:
             df['detail_name'] = df.container_id
             for container_id in containers:
-                df.loc[df.detail_name == container_id, 'detail_name'] = containers[container_id]
+                df.loc[df.detail_name == container_id, 'detail_name'] = containers[container_id]['name']
             df = df.drop('container_id', axis=1)
         else: # We use the default granularity from the name of the provider eg. "..._machine"  => [MACHINE]
             df['detail_name'] = f"[{self._metric_name.split('_')[-1]}]"

--- a/runner.py
+++ b/runner.py
@@ -361,7 +361,7 @@ class Runner:
         if self._usage_scenario.get('architecture') is not None and self._architecture != self._usage_scenario['architecture'].lower():
             raise RuntimeError(f"Specified architecture does not match system architecture: system ({self._architecture}) != specified ({self._usage_scenario.get('architecture')})")
 
-        self._sci['R-Dimension'] = self._usage_scenario.get('R-Dimension', None)
+        self._sci['R-Dimension'] = self._usage_scenario.get('sci', {}).get('R-Dimension', None)
 
     def check_running_containers(self):
         result = subprocess.run(['docker', 'ps' ,'--format', '{{.Names}}'],

--- a/runner.py
+++ b/runner.py
@@ -118,7 +118,7 @@ class Runner:
         self._tmp_folder = '/tmp/green-metrics-tool'
         self._usage_scenario = {}
         self._architecture = utils.get_architecture()
-        self._sci = {'R-Dimension': None, 'R': 0}
+        self._sci = {'R_d': None, 'R': 0}
 
 
         # transient variables that are created by the runner itself
@@ -361,7 +361,7 @@ class Runner:
         if self._usage_scenario.get('architecture') is not None and self._architecture != self._usage_scenario['architecture'].lower():
             raise RuntimeError(f"Specified architecture does not match system architecture: system ({self._architecture}) != specified ({self._usage_scenario.get('architecture')})")
 
-        self._sci['R-Dimension'] = self._usage_scenario.get('sci', {}).get('R-Dimension', None)
+        self._sci['R_d'] = self._usage_scenario.get('sci', {}).get('R_d', None)
 
     def check_running_containers(self):
         result = subprocess.run(['docker', 'ps' ,'--format', '{{.Names}}'],

--- a/runner.py
+++ b/runner.py
@@ -462,6 +462,9 @@ class Runner:
             machine_specs.update(machine_specs_root)
 
 
+        keys = ["measurement", "sci"]
+        measurement_config = {key: config.get(key, None) for key in keys}
+
         # Insert auxilary info for the run. Not critical.
         DB().query("""
             UPDATE projects
@@ -472,7 +475,7 @@ class Runner:
             """, params=(
             config['machine']['id'],
             escape(json.dumps(machine_specs), quote=False),
-            json.dumps(config['measurement']),
+            json.dumps(measurement_config),
             escape(json.dumps(self._usage_scenario), quote=False),
             self._original_filename,
             gmt_hash,

--- a/runner.py
+++ b/runner.py
@@ -1036,8 +1036,7 @@ class Runner:
                 stderr = ps['ps'].stderr
 
             if stdout:
-                stdout = stdout.splitlines()
-                for line in stdout:
+                for line in stdout.splitlines():
                     print('stdout from process:', ps['cmd'], line)
                     self.add_to_log(ps['container_name'], f"stdout: {line}", ps['cmd'])
 

--- a/runner.py
+++ b/runner.py
@@ -156,6 +156,8 @@ class Runner:
         self.__notes_helper.save_to_db(self._project_id)
 
     def check_configuration(self):
+        print(TerminalColors.HEADER, '\nStarting configuration check', TerminalColors.ENDC)
+
         if self._skip_config_check:
             print("Configuration check skipped")
             return
@@ -182,6 +184,7 @@ class Runner:
             )
 
     def checkout_repository(self):
+        print(TerminalColors.HEADER, '\nChecking out repository', TerminalColors.ENDC)
 
         if self._uri_type == 'URL':
             # always remove the folder if URL provided, cause -v directory binding always creates it

--- a/runner.py
+++ b/runner.py
@@ -118,7 +118,7 @@ class Runner:
         self._tmp_folder = '/tmp/green-metrics-tool'
         self._usage_scenario = {}
         self._architecture = utils.get_architecture()
-        self._sci = {'R': 0}
+        self._sci = {'R-Dimension': None, 'R': 0}
 
 
         # transient variables that are created by the runner itself
@@ -360,6 +360,8 @@ class Runner:
 
         if self._usage_scenario.get('architecture') is not None and self._architecture != self._usage_scenario['architecture'].lower():
             raise RuntimeError(f"Specified architecture does not match system architecture: system ({self._architecture}) != specified ({self._usage_scenario.get('architecture')})")
+
+        self._sci['R-Dimension'] = self._usage_scenario.get('R-Dimension', None)
 
     def check_running_containers(self):
         result = subprocess.run(['docker', 'ps' ,'--format', '{{.Names}}'],

--- a/runner.py
+++ b/runner.py
@@ -118,6 +118,8 @@ class Runner:
         self._tmp_folder = '/tmp/green-metrics-tool'
         self._usage_scenario = {}
         self._architecture = utils.get_architecture()
+        self._sci = {'R': 0}
+
 
         # transient variables that are created by the runner itself
         # these are accessed and processed on cleanup and then reset
@@ -971,6 +973,7 @@ class Runner:
                         'container_name': el['container'],
                         'read-notes-stdout': inner_el.get('read-notes-stdout', False),
                         'ignore-errors': inner_el.get('ignore-errors', False),
+                        'read-sci-stdout': inner_el.get('read-sci-stdout', False),
                         'detail_name': el['container'],
                         'detach': inner_el.get('detach', False),
                     })
@@ -1030,6 +1033,10 @@ class Runner:
                     if ps['read-notes-stdout']:
                         if note := self.__notes_helper.parse_note(line):
                             self.__notes_helper.add_note({'note': note[1], 'detail_name': ps['detail_name'], 'timestamp': note[0]})
+
+                    if ps['read-sci-stdout']:
+                        if match := re.match(r'GMT_SCI_R=(\d+)', line):
+                            self._sci['R'] += int(match[1])
             if stderr:
                 stderr = stderr.splitlines()
                 for line in stderr:
@@ -1367,7 +1374,7 @@ if __name__ == '__main__':
         # get all the metrics from the measurements table grouped by metric
         # loop over them issueing separate queries to the DB
         from phase_stats import build_and_store_phase_stats
-        build_and_store_phase_stats(project_id)
+        build_and_store_phase_stats(project_id, runner._sci)
 
 
         print(TerminalColors.OKGREEN,'\n\n####################################################################################')

--- a/tools/jobs.py
+++ b/tools/jobs.py
@@ -126,7 +126,7 @@ def _do_project_job(job_id, project_id, skip_config_check=False, docker_prune=Fa
     try:
         # Start main code. Only URL is allowed for cron jobs
         runner.run()
-        build_and_store_phase_stats(project_id)
+        build_and_store_phase_stats(project_id, runner._sci)
         insert_job('email', project_id=project_id)
         delete_job(job_id)
     except Exception as exc:

--- a/tools/phase_stats.py
+++ b/tools/phase_stats.py
@@ -131,7 +131,7 @@ def build_and_store_phase_stats(project_id, sci=None):
         csv_buffer.write(generate_csv_line(project_id, 'embodied_carbon_share_machine', '[SYSTEM]', f"{idx:03}_{phase['name']}", embodied_carbon_share_ug, 'TOTAL', None, None, 'ug'))
 
         if machine_co2 is not None and sci is not None and sci.get('R', None) is not None:
-            csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) * sci['R'], 'TOTAL', None, None, 'ug/R'))
+            csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) / sci['R'], 'TOTAL', None, None, 'ug/R'))
 
 
     csv_buffer.seek(0)  # Reset buffer position to the beginning

--- a/tools/phase_stats.py
+++ b/tools/phase_stats.py
@@ -131,7 +131,10 @@ def build_and_store_phase_stats(project_id, sci=None):
         csv_buffer.write(generate_csv_line(project_id, 'embodied_carbon_share_machine', '[SYSTEM]', f"{idx:03}_{phase['name']}", embodied_carbon_share_ug, 'TOTAL', None, None, 'ug'))
 
         if machine_co2 is not None and sci is not None and sci.get('R', None) is not None:
-            csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) / sci['R'], 'TOTAL', None, None, 'ug/R'))
+            if sci['R'] == 0:
+                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug), 'TOTAL', None, None, 'ug/R'))
+            else:
+                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) / sci['R'], 'TOTAL', None, None, 'ug/R'))
 
 
     csv_buffer.seek(0)  # Reset buffer position to the beginning

--- a/tools/phase_stats.py
+++ b/tools/phase_stats.py
@@ -11,12 +11,15 @@ sys.path.append(f"{CURRENT_DIR}/..")
 sys.path.append(f"{CURRENT_DIR}/../lib")
 
 from db import DB
+from global_config import GlobalConfig
 
 
 def generate_csv_line(project_id, metric, detail_name, phase_name, value, value_type, max_value, min_value, unit):
     return f"{project_id},{metric},{detail_name},{phase_name},{round(value)},{value_type},{round(max_value) if max_value is not None else ''},{round(min_value) if min_value is not None else ''},{unit},NOW()\n"
 
-def build_and_store_phase_stats(project_id):
+def build_and_store_phase_stats(project_id, sci=None):
+    config = GlobalConfig().config
+
     query = """
             SELECT metric, unit, detail_name
             FROM measurements
@@ -37,6 +40,8 @@ def build_and_store_phase_stats(project_id):
 
     for idx, phase in enumerate(phases[0]):
         network_io_bytes_total = [] # reset; # we use array here and sum later, because checking for 0 alone not enough
+
+        machine_co2 = None # reset
 
         select_query = """
             SELECT SUM(value), MAX(value), MIN(value), AVG(value), COUNT(value)
@@ -99,7 +104,7 @@ def build_and_store_phase_stats(project_id):
                 csv_buffer.write(generate_csv_line(project_id, f"{metric.replace('_energy_', '_power_')}", detail_name, f"{idx:03}_{phase['name']}", power_sum, 'MEAN', power_max, power_min, 'mW'))
 
                 if metric.endswith('_machine'):
-                    machine_co2 = ((value_sum / 3_600) * 475)
+                    machine_co2 = (value_sum / 3_600) * config['gsf-sci']['I']
                     csv_buffer.write(generate_csv_line(project_id, f"{metric.replace('_energy_', '_co2_')}", detail_name, f"{idx:03}_{phase['name']}", machine_co2, 'TOTAL', None, None, 'ug'))
 
 
@@ -114,11 +119,20 @@ def build_and_store_phase_stats(project_id):
             network_io_in_mJ = network_io_in_kWh * 3_600_000_000
             csv_buffer.write(generate_csv_line(project_id, 'network_energy_formula_global', '[FORMULA]', f"{idx:03}_{phase['name']}", network_io_in_mJ, 'TOTAL', None, None, 'mJ'))
             # co2 calculations
-            network_io_co2_in_ug = network_io_in_kWh * 475 * 1_000_000
+            network_io_co2_in_ug = network_io_in_kWh * config['gsf-sci']['I'] * 1_000_000
             csv_buffer.write(generate_csv_line(project_id, 'network_co2_formula_global', '[FORMULA]', f"{idx:03}_{phase['name']}", network_io_co2_in_ug, 'TOTAL', None, None, 'ug'))
 
-        # also create the phase time metric
-        csv_buffer.write(generate_csv_line(project_id, 'phase_time_syscall_system', '[SYSTEM]', f"{idx:03}_{phase['name']}", phase['end']-phase['start'], 'TOTAL', None, None, 'us'))
+        duration = phase['end']-phase['start']
+        csv_buffer.write(generate_csv_line(project_id, 'phase_time_syscall_system', '[SYSTEM]', f"{idx:03}_{phase['name']}", duration, 'TOTAL', None, None, 'us'))
+
+        duration_in_years = duration / (1_000_000 * 60 * 60 * 24 * 365)
+        embodied_carbon_share_g = (duration_in_years / (config['gsf-sci']['EL']) ) * config['gsf-sci']['TE'] * config['gsf-sci']['RS']
+        embodied_carbon_share_ug = embodied_carbon_share_g * 1_000_000
+        csv_buffer.write(generate_csv_line(project_id, 'embodied_carbon_share_machine', '[SYSTEM]', f"{idx:03}_{phase['name']}", embodied_carbon_share_ug, 'TOTAL', None, None, 'ug'))
+
+        if machine_co2 is not None:
+            csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) * sci['R'], 'TOTAL', None, None, 'ug/R'))
+
 
     csv_buffer.seek(0)  # Reset buffer position to the beginning
     DB().copy_from(

--- a/tools/phase_stats.py
+++ b/tools/phase_stats.py
@@ -104,7 +104,7 @@ def build_and_store_phase_stats(project_id, sci=None):
                 csv_buffer.write(generate_csv_line(project_id, f"{metric.replace('_energy_', '_power_')}", detail_name, f"{idx:03}_{phase['name']}", power_sum, 'MEAN', power_max, power_min, 'mW'))
 
                 if metric.endswith('_machine'):
-                    machine_co2 = (value_sum / 3_600) * config['gsf-sci']['I']
+                    machine_co2 = (value_sum / 3_600) * config['sci']['I']
                     csv_buffer.write(generate_csv_line(project_id, f"{metric.replace('_energy_', '_co2_')}", detail_name, f"{idx:03}_{phase['name']}", machine_co2, 'TOTAL', None, None, 'ug'))
 
 
@@ -119,14 +119,14 @@ def build_and_store_phase_stats(project_id, sci=None):
             network_io_in_mJ = network_io_in_kWh * 3_600_000_000
             csv_buffer.write(generate_csv_line(project_id, 'network_energy_formula_global', '[FORMULA]', f"{idx:03}_{phase['name']}", network_io_in_mJ, 'TOTAL', None, None, 'mJ'))
             # co2 calculations
-            network_io_co2_in_ug = network_io_in_kWh * config['gsf-sci']['I'] * 1_000_000
+            network_io_co2_in_ug = network_io_in_kWh * config['sci']['I'] * 1_000_000
             csv_buffer.write(generate_csv_line(project_id, 'network_co2_formula_global', '[FORMULA]', f"{idx:03}_{phase['name']}", network_io_co2_in_ug, 'TOTAL', None, None, 'ug'))
 
         duration = phase['end']-phase['start']
         csv_buffer.write(generate_csv_line(project_id, 'phase_time_syscall_system', '[SYSTEM]', f"{idx:03}_{phase['name']}", duration, 'TOTAL', None, None, 'us'))
 
         duration_in_years = duration / (1_000_000 * 60 * 60 * 24 * 365)
-        embodied_carbon_share_g = (duration_in_years / (config['gsf-sci']['EL']) ) * config['gsf-sci']['TE'] * config['gsf-sci']['RS']
+        embodied_carbon_share_g = (duration_in_years / (config['sci']['EL']) ) * config['sci']['TE'] * config['sci']['RS']
         embodied_carbon_share_ug = decimal.Decimal(embodied_carbon_share_g * 1_000_000)
         csv_buffer.write(generate_csv_line(project_id, 'embodied_carbon_share_machine', '[SYSTEM]', f"{idx:03}_{phase['name']}", embodied_carbon_share_ug, 'TOTAL', None, None, 'ug'))
 

--- a/tools/phase_stats.py
+++ b/tools/phase_stats.py
@@ -131,10 +131,10 @@ def build_and_store_phase_stats(project_id, sci=None):
         csv_buffer.write(generate_csv_line(project_id, 'embodied_carbon_share_machine', '[SYSTEM]', f"{idx:03}_{phase['name']}", embodied_carbon_share_ug, 'TOTAL', None, None, 'ug'))
 
         if machine_co2 is not None and sci is not None and sci.get('R', None) is not None:
-            if sci.get('R-Dimension', None):
-                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug), 'TOTAL', None, None, f"ugCO2e/{sci['R-Dimension']}"))
+            if sci.get('R_d', None):
+                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug), 'TOTAL', None, None, f"ugCO2e/{sci['R_d']}"))
             else:
-                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) / sci['R'], 'TOTAL', None, None, f"ugCO2e/{sci['R-Dimension']}"))
+                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) / sci['R'], 'TOTAL', None, None, f"ugCO2e/{sci['R_d']}"))
 
 
     csv_buffer.seek(0)  # Reset buffer position to the beginning

--- a/tools/phase_stats.py
+++ b/tools/phase_stats.py
@@ -130,11 +130,9 @@ def build_and_store_phase_stats(project_id, sci=None):
         embodied_carbon_share_ug = decimal.Decimal(embodied_carbon_share_g * 1_000_000)
         csv_buffer.write(generate_csv_line(project_id, 'embodied_carbon_share_machine', '[SYSTEM]', f"{idx:03}_{phase['name']}", embodied_carbon_share_ug, 'TOTAL', None, None, 'ug'))
 
-        if machine_co2 is not None and sci is not None and sci.get('R', None) is not None:
-            if sci.get('R_d', None):
-                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug), 'TOTAL', None, None, f"ugCO2e/{sci['R_d']}"))
-            else:
-                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) / sci['R'], 'TOTAL', None, None, f"ugCO2e/{sci['R_d']}"))
+        if phase['name'] == '[RUNTIME]' and machine_co2 is not None and sci is not None \
+                         and sci.get('R', None) is not None and sci['R'] != 0:
+            csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) / sci['R'], 'TOTAL', None, None, f"ugCO2e/{sci['R_d']}"))
 
 
     csv_buffer.seek(0)  # Reset buffer position to the beginning

--- a/tools/phase_stats.py
+++ b/tools/phase_stats.py
@@ -2,8 +2,8 @@
 from io import StringIO
 import sys
 import os
+import decimal
 import faulthandler
-
 faulthandler.enable()  # will catch segfaults and write to STDERR
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -127,10 +127,10 @@ def build_and_store_phase_stats(project_id, sci=None):
 
         duration_in_years = duration / (1_000_000 * 60 * 60 * 24 * 365)
         embodied_carbon_share_g = (duration_in_years / (config['gsf-sci']['EL']) ) * config['gsf-sci']['TE'] * config['gsf-sci']['RS']
-        embodied_carbon_share_ug = embodied_carbon_share_g * 1_000_000
+        embodied_carbon_share_ug = decimal.Decimal(embodied_carbon_share_g * 1_000_000)
         csv_buffer.write(generate_csv_line(project_id, 'embodied_carbon_share_machine', '[SYSTEM]', f"{idx:03}_{phase['name']}", embodied_carbon_share_ug, 'TOTAL', None, None, 'ug'))
 
-        if machine_co2 is not None:
+        if machine_co2 is not None and sci is not None and sci.get('R', None) is not None:
             csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) * sci['R'], 'TOTAL', None, None, 'ug/R'))
 
 

--- a/tools/phase_stats.py
+++ b/tools/phase_stats.py
@@ -131,10 +131,10 @@ def build_and_store_phase_stats(project_id, sci=None):
         csv_buffer.write(generate_csv_line(project_id, 'embodied_carbon_share_machine', '[SYSTEM]', f"{idx:03}_{phase['name']}", embodied_carbon_share_ug, 'TOTAL', None, None, 'ug'))
 
         if machine_co2 is not None and sci is not None and sci.get('R', None) is not None:
-            if sci['R-dimension']:
-                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug), 'TOTAL', None, None, f"ugCO2e/{sci['R-dimension']}"))
+            if sci.get('R-Dimension', None):
+                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug), 'TOTAL', None, None, f"ugCO2e/{sci['R-Dimension']}"))
             else:
-                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) / sci['R'], 'TOTAL', None, None, f"ugCO2e/{sci['R-dimension']}"))
+                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) / sci['R'], 'TOTAL', None, None, f"ugCO2e/{sci['R-Dimension']}"))
 
 
     csv_buffer.seek(0)  # Reset buffer position to the beginning

--- a/tools/phase_stats.py
+++ b/tools/phase_stats.py
@@ -131,10 +131,10 @@ def build_and_store_phase_stats(project_id, sci=None):
         csv_buffer.write(generate_csv_line(project_id, 'embodied_carbon_share_machine', '[SYSTEM]', f"{idx:03}_{phase['name']}", embodied_carbon_share_ug, 'TOTAL', None, None, 'ug'))
 
         if machine_co2 is not None and sci is not None and sci.get('R', None) is not None:
-            if sci['R'] == 0:
-                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug), 'TOTAL', None, None, 'ug/R'))
+            if sci['R-dimension']:
+                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug), 'TOTAL', None, None, f"ugCO2e/{sci['R-dimension']}"))
             else:
-                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) / sci['R'], 'TOTAL', None, None, 'ug/R'))
+                csv_buffer.write(generate_csv_line(project_id, 'software_carbon_intensity_global', '[SYSTEM]', f"{idx:03}_{phase['name']}", (machine_co2 + embodied_carbon_share_ug) / sci['R'], 'TOTAL', None, None, f"ugCO2e/{sci['R-dimension']}"))
 
 
     csv_buffer.seek(0)  # Reset buffer position to the beginning


### PR DESCRIPTION
This branch introduces the capability to output a new metric: [Green Software Foundation SCI](https://sci-guide.greensoftware.foundation/)

The parts to derive the metric have to be defined in two places:
- The `usage_scenario.yml` (which sets the dimension *R_d*)
- The `config.yml`, which sets the machine specific parameters like *TE*, *RS* etc.

The actual ticks for the unit of work (*R*) are captured from the containers and processes STDOUT. This has to be activated by setting `log-stdout` and `read-sci-stdout` to **True**.

The metric will atm only be calculated for the **RUNTIME** phase and be shown in the Dashboard.
If an SCI was configured also the parameters will be shown in the *Measurements* Tab.


<img width="612" alt="Screenshot 2023-08-04 at 10 54 22 AM" src="https://github.com/green-coding-berlin/green-metrics-tool/assets/250671/d06b994b-04c3-4449-b86f-d33e2da271ee">

<img width="1175" alt="Screenshot 2023-08-04 at 10 53 40 AM" src="https://github.com/green-coding-berlin/green-metrics-tool/assets/250671/44a16453-d321-4e98-8809-bbaa63a0948d">

Future work will include making the SCI an actual metric_provider and thus allowing to capture it in every phase, optionally with having different dimensions per phase even.

