### PR TITLE
Added python and system packages listing

### DIFF
--- a/lib/hardware_info.py
+++ b/lib/hardware_info.py
@@ -78,7 +78,7 @@ linux_info_list = [
     [rpwr, 'Hardware Model', '/usr/bin/hostnamectl', r'Hardware Model:\s*(?P<o>.*)'],
     [rpwr, 'Docker Info', 'docker info', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Docker Version', 'docker version', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
-    [rpwr, 'Docker containers', 'docker ps -a', r'(?P<o>.*)'],
+    [rpwr, 'Docker Containers', 'docker ps -a', r'(?P<o>.*)'],
     [rpwr, 'Installed System Packages', 'if [ -f /etc/lsb-release ]; then dpkg -l | cat ; elif [ -f /etc/redhat-release ]; then dnf list installed | cat; fi', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Installed Python Packages', f"{sys.executable} -m pip freeze", r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Processes', '/usr/bin/ps -aux', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
@@ -110,7 +110,7 @@ mac_info_list = [
     [rpwr, 'Uname', 'uname -a', r'(?P<o>.*)'],
     [rpwr, 'Docker Info', 'docker info', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Docker Version', 'docker version', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
-    [rpwr, 'Docker containers', 'docker ps -a', r'(?P<o>.*)'],
+    [rpwr, 'Docker Containers', 'docker ps -a', r'(?P<o>.*)'],
     [rpwr, 'Processes', '/bin/ps -ax', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Network Interfaces', 'ifconfig | grep -E "flags|ether"', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
 

--- a/lib/hardware_info.py
+++ b/lib/hardware_info.py
@@ -78,6 +78,7 @@ linux_info_list = [
     [rpwr, 'Hardware Model', '/usr/bin/hostnamectl', r'Hardware Model:\s*(?P<o>.*)'],
     [rpwr, 'Docker Info', 'docker info', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Docker Version', 'docker version', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
+    [rpwr, 'Docker containers', 'docker ps -a', r'(?P<o>.*)'],
     [rpwr, 'Installed System Packages', 'if [ -f /etc/lsb-release ]; then dpkg -l | cat ; elif [ -f /etc/redhat-release ]; then dnf list installed | cat; fi', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Installed Python Packages', f"{sys.executable} -m pip freeze", r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Processes', '/usr/bin/ps -aux', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
@@ -109,6 +110,7 @@ mac_info_list = [
     [rpwr, 'Uname', 'uname -a', r'(?P<o>.*)'],
     [rpwr, 'Docker Info', 'docker info', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Docker Version', 'docker version', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
+    [rpwr, 'Docker containers', 'docker ps -a', r'(?P<o>.*)'],
     [rpwr, 'Processes', '/bin/ps -ax', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Network Interfaces', 'ifconfig | grep -E "flags|ether"', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
 

--- a/lib/hardware_info.py
+++ b/lib/hardware_info.py
@@ -79,7 +79,7 @@ linux_info_list = [
     [rpwr, 'Docker Info', 'docker info', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Docker Version', 'docker version', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Docker Containers', 'docker ps -a', r'(?P<o>.*)'],
-    [rpwr, 'Installed System Packages', 'if [ -f /etc/lsb-release ]; then dpkg -l | cat ; elif [ -f /etc/redhat-release ]; then dnf list installed | cat; fi', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
+    [rpwr, 'Installed System Packages', 'if [ -f /etc/lsb-release ]; then dpkg -l ; elif [ -f /etc/redhat-release ]; then dnf list installed ; fi', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Installed Python Packages', f"{sys.executable} -m pip freeze", r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Processes', '/usr/bin/ps -aux', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [

--- a/lib/hardware_info.py
+++ b/lib/hardware_info.py
@@ -4,9 +4,10 @@ root.
 '''
 import re
 import os
-import subprocess
 import platform
 import pprint
+import subprocess
+import sys
 
 REGEX_PARAMS = re.MULTILINE | re.IGNORECASE
 
@@ -77,6 +78,8 @@ linux_info_list = [
     [rpwr, 'Hardware Model', '/usr/bin/hostnamectl', r'Hardware Model:\s*(?P<o>.*)'],
     [rpwr, 'Docker Info', 'docker info', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Docker Version', 'docker version', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
+    [rpwr, 'Installed System Packages', 'if [ -f /etc/lsb-release ]; then dpkg -l | cat ; elif [ -f /etc/redhat-release ]; then dnf list installed | cat; fi', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
+    [rpwr, 'Installed Python Packages', f"{sys.executable} -m pip freeze", r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rpwr, 'Processes', '/usr/bin/ps -aux', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [
         rpwrs,


### PR DESCRIPTION
@ribalba Can you please check if this works on Fedora.

I was not sure if I should do `dnf list installed` or `rpm -qa`.

Also I hacked it into a bash query, which I think is nicer than doing it in python. Or did you plan already for a mechanism to make that if/else smoother in Python?

Demo Run with data: https://metrics.green-coding.berlin/stats.html?id=7b635c8e-5dbc-4bc2-b2c5-99d373cce558