### PR TITLE
Client has now two distinguished sleep times

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -25,8 +25,10 @@ admin:
 cluster:
   api_url: __API_URL__
   metrics_url: __METRICS_URL__
+
 client:
-  sleep_time: 300
+  sleep_time_no_job: 300
+  sleep_time_after_job: 300
 
 machine:
   id: 1

--- a/tools/client.py
+++ b/tools/client.py
@@ -40,6 +40,7 @@ if __name__ == '__main__':
 
         if not job:
             set_status('job_no')
+            time.sleep(GlobalConfig().config['client']['sleep_time_no_job'])
         else:
             set_status('job_start', '', job.run_id)
             try:
@@ -60,4 +61,4 @@ if __name__ == '__main__':
 
             set_status('cleanup_stop', f"stdout: {result.stdout}, stderr: {result.stderr}")
 
-            time.sleep(GlobalConfig().config['client']['sleep_time'])
+            time.sleep(GlobalConfig().config['client']['sleep_time_after_job'])


### PR DESCRIPTION
So far we had only one sleep time, which was initially triggered for waiting when no job was available.

However the client also needs a time to sleep when a measurement succeeded