### PR TITLE
Adding current clocksource in linux

### DIFF
--- a/lib/hardware_info.py
+++ b/lib/hardware_info.py
@@ -97,6 +97,8 @@ linux_info_list = [
     [rpwrs, 'SGX', f"{os.path.join(CURRENT_PATH, '../tools/sgx_enable')} -s", r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
     [rfwr, 'IO scheduling', '/sys/block/sda/queue/scheduler', r'(?P<o>.*)'],
     [rpwr, 'Network Interfaces', 'ip addr | grep ether -B 1', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
+    [rfwr, 'Current Clocksource', '/sys/devices/system/clocksource/clocksource0/current_clocksource', r'(?P<o>.*)'],
+
 ]
 
 # This is a very slimmed down version in comparison to the linux list. This is because we will not be using this


### PR DESCRIPTION
according to timing problems outlined here: https://www.brendangregg.com/blog/2021-09-26/the-speed-of-time.html

The clocksource in Linux can be an extreme source of cost for reading from it. Since the GMT does a lot of timestamping for all its reporters we need to log it.

Usually linux sets `tsc` as the most performant clocksource (https://access.redhat.com/solutions/18627) 

However in cloud situations or VMs, where we often run, this situation can be different and virtualized or low-granular clocks are used.

To test the clocksource this script can be used:

```C
#include <time.h>
void main()
{
    int rc;
    long i;
    struct timespec ts;

    for(i=0; i<10000000; i++) {
        rc = clock_gettime(CLOCK_MONOTONIC, &ts);
    }
}
```

Once compiled one iterates and sets all the clocksources in `/sys/devices/system/clocksource/clocksource0/available_clocksource` and can determine the cost of reading from them.

Example:
```
echo hpet > /sys/devices/system/clocksource/clocksource0/current_clocksource
time /tmp/a.out
``` 

Result example for `tsc`:
```
root@esprimo-p956:/tmp# echo tsc > /sys/devices/system/clocksource/clocksource0/current_clocksource
root@esprimo-p956:/tmp# time ./a.out

real	0m0.181s
user	0m0.177s
sys	0m0.004
``` 

Result example for HPE:
```
root@esprimo-p956:/tmp# echo hpet > /sys/devices/system/clocksource/clocksource0/current_clocksource
root@esprimo-p956:/tmp# time ./a.out

real	0m45.446s
user	0m5.196s
sys	0m40.249s
```