### PR TITLE
Adding report url instead of just ID

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -1424,7 +1424,7 @@ if __name__ == '__main__':
 
 
         print(TerminalColors.OKGREEN,'\n\n####################################################################################')
-        print(f"Please access your report with the ID: {successful_run_id}")
+        print(f"Please access your report on the URL {GlobalConfig().config['cluster']['metrics_url']}/stats.html?id={successful_run_id}")
         print('####################################################################################\n\n', TerminalColors.ENDC)
 
     except FileNotFoundError as e:


### PR DESCRIPTION
Instead of this:
```
####################################################################################
Please access your with the ID c0a0a5c8-efbf-4b1c-9549-1bbb1d3c260d
####################################################################################
```

The GMT now reports this:
```
####################################################################################
Please access your report on the URL http://metrics.green-coding.internal:9142/stats.html?id=c0a0a5c8-efbf-4b1c-9549-1bbb1d3c260d
####################################################################################
```

This makes it easier for very unexperienced users to understand that a website is attached to the GMT and where it was configured.