### PR TITLE
Disable Docker CLI hints

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -362,6 +362,10 @@ class Runner:
 
         self._sci['R_d'] = self._usage_scenario.get('sci', {}).get('R_d', None)
 
+    def prepare_docker(self):
+        # Disable Docker CLI hints (e.g. "What's Next? ...")
+        os.environ['DOCKER_CLI_HINTS'] = 'false'
+
     def check_running_containers(self):
         result = subprocess.run(['docker', 'ps' ,'--format', '{{.Names}}'],
                                 stdout=subprocess.PIPE,
@@ -1211,6 +1215,7 @@ class Runner:
             self.initial_parse()
             self.import_metric_providers()
             self.populate_image_names()
+            self.prepare_docker()
             self.check_running_containers()
             self.remove_docker_images()
             self.download_dependencies()

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -71,6 +71,7 @@ def run_until(runner, step):
         runner.initial_parse()
         runner.import_metric_providers()
         runner.populate_image_names()
+        runner.prepare_docker()
         runner.check_running_containers()
         runner.check_system()
         runner.remove_docker_images()


### PR DESCRIPTION
Fixes #554

I have chosen the option to disable the Docker CLI hints via the environment variable `DOCKER_CLI_HINTS=false` in the current session.

Another option could be to permanently disable them in the Docker settings (`$HOME/.docker/config.json`):

```json
"plugins": {
    "-x-cli-hints": {
      "enabled": "false"
    }
}
```