### PR TITLE
Document tests dependencies

### DIFF
--- a/tests/README.MD
+++ b/tests/README.MD
@@ -1,6 +1,8 @@
 ## Pre-reqs
-Make sure you have `pytest` and `pydantic` installed:
-`pip install pytest pydantic`
+Make sure you have the required dev dependencies installed:
+```sh
+python3 -m pip install -r ../requirements-dev.txt
+```
 
 We assume that your green-metrics-tool is already set up to work on your machine, as it will use your local config.yml
 file to determine which metric providers can be utilized in the tests.

--- a/tests/README.MD
+++ b/tests/README.MD
@@ -1,6 +1,16 @@
+# Tests
+
 ## Pre-reqs
+
+Make sure you have venv activated:
+
+```bash
+source ../venv/bin/activate
+```
+
 Make sure you have the required dev dependencies installed:
-```sh
+
+```bash
 python3 -m pip install -r ../requirements-dev.txt
 ```
 
@@ -8,6 +18,7 @@ We assume that your green-metrics-tool is already set up to work on your machine
 file to determine which metric providers can be utilized in the tests.
 
 ## First time setup
+
 run:
 
 `python3 setup-test-env.py`
@@ -20,6 +31,7 @@ You will need to re-run this setup script if new metric providers are added or t
 significant way.
 
 ## Running
+
 To run the tests, you need to first start the test containers, then run pytest, and afterwards stop the containers.
 There are a few scripts to make this easy.
 


### PR DESCRIPTION
README for running tests is missing some information.
E.g. installing `pytest` and `pydantic` is not sufficient. I think it makes sense to just install every dev dependency before running the tests.

This change was part of PR #556 that won't get merged.