### PR TITLE
Allow characters . / : in env var values

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -759,11 +759,11 @@ class Runner:
                         raise RuntimeError(f"Docker container setup environment var key had wrong format. Only ^[A-Z_]+[A-Z0-9_]*$ allowed: {env_key} - Maybe consider using --allow-unsafe or --skip-unsafe")
 
                     if not self._allow_unsafe and \
-                        re.search(r'^[a-zA-Z0-9_]+[a-zA-Z0-9_-]*$', env_value) is None:
+                        re.search(r'^[a-zA-Z0-9_]{1}[a-zA-Z0-9_.:/-]{0,1023}$', env_value) is None:
                         if self._skip_unsafe:
-                            print(TerminalColors.WARNING, arrows(f"Found environment var value with wrong format. Only ^[A-Z_]+[a-zA-Z0-9_]*$ allowed: {env_value} - Skipping"), TerminalColors.ENDC)
+                            print(TerminalColors.WARNING, arrows("Found environment var value with wrong format. Only ^[a-zA-Z0-9_]{1}[a-zA-Z0-9_.:/-]{0,1023}$ allowed: " + env_value + " - Skipping"), TerminalColors.ENDC)
                             continue
-                        raise RuntimeError(f"Docker container setup environment var value had wrong format. Only ^[A-Z_]+[a-zA-Z0-9_]*$ allowed: {env_value} - Maybe consider using --allow-unsafe --skip-unsafe")
+                        raise RuntimeError("Docker container setup environment var value had wrong format. Only ^[a-zA-Z0-9_]{1}[a-zA-Z0-9_.:/-]{0,1023}$ allowed: " + env_value + " - Maybe consider using --allow-unsafe --skip-unsafe")
 
                     docker_run_string.append('-e')
                     docker_run_string.append(f"{env_key}={env_value}")

--- a/tests/data/usage_scenarios/env_vars_stress.yml
+++ b/tests/data/usage_scenarios/env_vars_stress.yml
@@ -12,6 +12,8 @@ services:
     environment:
       TESTALLOWED: 'alpha-num123_'
       TEST1_ALLOWED: 'alpha-key-num123_'
+      TEST2_ALLOWED: 'http://localhost:8080'
+      TEST3_ALLOWED: 'example.com'
 flow:
   - name: Stress
     container: test-container

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -100,6 +100,8 @@ def test_env_variable_unsafe_false():
     print("Env var output is ", env_var_output)
     assert 'TESTALLOWED=alpha-num123_' in env_var_output, Tests.assertion_info('TESTALLOWED=alpha-num123_', env_var_output)
     assert 'TEST1_ALLOWED=alpha-key-num123_' in env_var_output, Tests.assertion_info('TEST1_ALLOWED=alpha-key-num123_', env_var_output)
+    assert 'TEST2_ALLOWED=http://localhost:8080' in env_var_output, Tests.assertion_info('TEST2_ALLOWED=http://localhost:8080', env_var_output)
+    assert 'TEST3_ALLOWED=example.com' in env_var_output, Tests.assertion_info('TEST3_ALLOWED=example.com', env_var_output)
 
 def test_env_variable_skip_unsafe_true():
     runner = Tests.setup_runner(usage_scenario='env_vars_stress_unallowed.yml', skip_unsafe=True, dry_run=True)


### PR DESCRIPTION
Fixes #569

Also checks if the value is not longer than 1024.