### PR TITLE
Hovering over a unit to see raw value

### DIFF
--- a/frontend/js/helpers/metric-boxes.js
+++ b/frontend/js/helpers/metric-boxes.js
@@ -253,7 +253,7 @@ const displaySimpleMetricBox = (phase, metric_name, metric_data, detail_name, de
 
     updateKeyMetric(
         phase, metric_name, METRIC_MAPPINGS[metric_name]['clean_name'], detail_name,
-        value , std_dev_text, unit,
+        value , std_dev_text, unit, detail_data.mean, metric_data.unit,
         METRIC_MAPPINGS[metric_name]['explanation'], METRIC_MAPPINGS[metric_name]['source']
     );
 }
@@ -310,7 +310,7 @@ const displayDiffMetricBox = (phase, metric_name, metric_data, detail_name, deta
 
     updateKeyMetric(
         phase, metric_name, METRIC_MAPPINGS[metric_name]['clean_name'], detail_name,
-        value, '', metric_data.unit,
+        value, '', metric_data.unit, null, null,
         METRIC_MAPPINGS[metric_name]['explanation'], METRIC_MAPPINGS[metric_name]['source']
     );
 
@@ -354,7 +354,7 @@ const calculateCO2 = (phase, total_CO2_in_ug) => {
     }
 }
 
-const updateKeyMetric = (phase, metric_name, clean_name, detail_name, value, std_dev_text, unit, explanation, source) => {
+const updateKeyMetric = (phase, metric_name, clean_name, detail_name, value, std_dev_text, unit, raw_value, raw_unit, explanation, source) => {
 
     let selector = null;
     // key metrics are already there, cause we want a fixed order, so we just replace
@@ -380,6 +380,9 @@ const updateKeyMetric = (phase, metric_name, clean_name, detail_name, value, std
 
 
     document.querySelector(`div.tab[data-tab='${phase}'] ${selector} .value span`).innerText = `${(value)} ${std_dev_text}`
+
+    document.querySelector(`div.tab[data-tab='${phase}'] ${selector} .value`).setAttribute('title', `${raw_value} [${raw_unit}]`)
+
     document.querySelector(`div.tab[data-tab='${phase}'] ${selector} .si-unit`).innerText = `[${unit}]`
     if(std_dev_text != '') document.querySelector(`div.tab[data-tab='${phase}'] ${selector} .metric-type`).innerText = `(AVG + STD.DEV)`;
     else if(String(value).indexOf('%') !== -1) document.querySelector(`div.tab[data-tab='${phase}'] ${selector} .metric-type`).innerText = `(Diff. in %)`;


### PR DESCRIPTION
Since we currently do not have auto-scaling for the key values to make them more consistent we have sometimes the case that a value is to small to show.

This introduces the hover functionality, so that at least the raw value can be seen
<img width="277" alt="Screenshot 2023-12-01 at 2 31 27 PM" src="https://github.com/green-coding-berlin/green-metrics-tool/assets/250671/5112204a-decc-4488-b666-62a5154bd0c5">
