### PR TITLE
fix for issue where tests on external PR's will fail when attempting to write to cache

### DIFF
--- a/.github/actions/gmt-pytest/action.yml
+++ b/.github/actions/gmt-pytest/action.yml
@@ -60,9 +60,21 @@ runs:
         password: ${{ inputs.github-token }}
 
     - name: Build docker-compose
+      id: build-docker-compose
       shell: bash
       working-directory: ${{ inputs.gmt-directory }}/docker
-      run: docker buildx bake --file test-compose.yml --file docker-compose-cache.json
+      run: |
+        { DOCKER_OUTPUT=$(docker buildx bake --file test-compose.yml --file docker-compose-cache.json 2>&1); DOCKER_EXIT_CODE=$?; } || true
+        if [ "$DOCKER_EXIT_CODE" -ne 0 ]; then
+          echo "Docker build failed with exit code $DOCKER_EXIT_CODE"
+          echo "buildx output:"
+          echo $DOCKER_OUTPUT
+          if echo "$DOCKER_OUTPUT" | grep -q "403 Forbidden"; then
+            echo "Docker build failed due to permissions issue. Continuing..."
+          else
+              exit 1
+          fi
+        fi
 
     - name: Start Test container
       shell: bash


### PR DESCRIPTION
We have an issue where some external PR's will fail because they attempt to write to the gunicorn cache and recieve a 403 Forbidden error, failing the entire pipeline.

I think we want to keep the security restriction, but the pipeline should continue. So the buildx command itself will now always return a success. However the pipeline should fail if the buildx command fails for any other reason, so I capture the (real) exit code and build output and will still fail on anything that is not a 403 Forbidden.

Unfortunately I don't see a quick/easy way to limit this to just external PR's, and our tests failing on cache issues isn't necessarily desired behaviour anyways, so this is now the default behaviour on all test runs. This does mean if we do have actual cache permissions errors they will be harder to spot.

I could restrict this to test runs triggered by PR's only (external or otherwise), and use the basic build command on all other triggers. Thoughts?