### PR TITLE
Fix frontend flow menu to wrap automatically

### DIFF
--- a/frontend/compare.html
+++ b/frontend/compare.html
@@ -187,7 +187,7 @@
                 Runtime can contain multiple flows.
                 By default all runtime flows are aggregated. Please select a separate flow if needed.
             </div>
-            <div id="runtime-sub-phases" class="ui top attached tabular menu">
+            <div id="runtime-sub-phases" class="ui top attached tabular wrapping menu">
                 <a class="active item" data-tab="[[RUNTIME]]">All Flows</a>
                 <a class="item runtime-step" data-tab="" style="display:none;"></a> <!-- empty element for copying. Usage phases will be inserted before -->
             </div>

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -246,7 +246,7 @@
                 Runtime can contain multiple flows.
                 By default all runtime flows are aggregated. Please select a separate flow if needed.
             </div>
-            <div id="runtime-sub-phases" class="ui top attached tabular menu">
+            <div id="runtime-sub-phases" class="ui top attached tabular wrapping menu">
                 <a class="active item" data-tab="[[RUNTIME]]">All Flows</a>
                 <a class="item runtime-step" data-tab="" style="display:none;"></a> <!-- empty element for copying. Usage phases will be inserted before -->
             </div>


### PR DESCRIPTION
If there are many flows some of them are not visible and clickable in the frontend.
[Example measurement](https://metrics.green-coding.berlin/stats.html?id=b5478c99-c8b4-4f65-a25b-99180f5ced2f):

![image](https://github.com/green-coding-berlin/green-metrics-tool/assets/7796322/ee5946fe-953a-4c30-b15c-3ffbe0c88a1d)

This PR adds the `wrapping` attribute to the menu ([→Fomantic docs](https://fomantic-ui.com/collections/menu.html#wrapping)).

Result:

![image](https://github.com/green-coding-berlin/green-metrics-tool/assets/7796322/ad5cab74-fae3-4a79-b307-256059cc394d)
