### PR TITLE
Make loading of detailed measurements optional

### DIFF
--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -7,6 +7,10 @@ var display_in_metric_units = localStorage.getItem('display_in_metric_units');
 if(display_in_metric_units == 'true') display_in_metric_units = true;
 else display_in_metric_units = false;
 
+var fetch_detailed_measurements = localStorage.getItem('fetch_detailed_measurements');
+if(fetch_detailed_measurements == 'true') fetch_detailed_measurements = true;
+else fetch_detailed_measurements = false;
+
 let toggleWatts = () => {
     localStorage.setItem('display_in_watts', !display_in_watts);
     window.location.reload();
@@ -14,6 +18,11 @@ let toggleWatts = () => {
 
 let toggleUnits = () => {
     localStorage.setItem('display_in_metric_units', !display_in_metric_units);
+    window.location.reload();
+}
+
+let toggleDetailedMeasurements = () => {
+    localStorage.setItem('fetch_detailed_measurements', !fetch_detailed_measurements);
     window.location.reload();
 }
 
@@ -28,6 +37,10 @@ let toggleUnits = () => {
 
       if(display_in_metric_units) $("#units-display").text("Currently showing metric units");
       else $("#units-display").text("Currently showing imperial units");
+
+      if(fetch_detailed_measurements) $("#fetch-detailed-measurements-display").text("Currently fetching detailed measurements by default");
+      else $("#fetch-detailed-measurements-display").text("Currently not fetching detailed measurements by default");
+
 
     });
 

--- a/frontend/js/stats.js
+++ b/frontend/js/stats.js
@@ -404,7 +404,8 @@ $(document).ready( (e) => {
         renderBadges(url_params);
 
         fillRunData(run_data);
-        console.log(phase_stats_data);
+
+        displayNetworkIntercepts(network_data);
 
         if(phase_stats_data != null) {
             displayComparisonMetrics(phase_stats_data)
@@ -413,8 +414,6 @@ $(document).ready( (e) => {
         if (localStorage.getItem('fetch_detailed_measurements') === 'true') {
             getDetailedMeasurements(url_params);
         }
-
-        //displayNetworkIntercepts(network_data);
 
         // after all charts instances have been placed
         // the flexboxes might have rearranged. We need to trigger resize

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -49,6 +49,11 @@
                           <td><span id="units-display"></span></td>
                           <td><button class="ui positive ui small button" onclick="toggleUnits();">Toggle</button></td>
                         </tr>
+                        <tr>
+                          <td>Fetch detailed measurements</td>
+                          <td><span id="fetch-detailed-measurements-display"></span></td>
+                          <td><button class="ui positive ui small button" onclick="toggleDetailedMeasurements();">Toggle</button></td>
+                        </tr>
                       </tbody>
                     </table>
 

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -347,7 +347,21 @@
             </div>
         </div>
 
-        <div class="ui two cards" id="api-loader">
+        <div id="loader-question" class="ui icon info message blue">
+            <i class="info circle icon"></i>
+
+                <div class="content">
+                    <div class="header">
+                        Detailed data is not displayed automatically
+                    </div>
+                    <p>Please click the button below to fetch data.</p>
+                    <p>You can change the default behaviour under <a href="/settings.html" style="text-decoration: underline; font-weight: bold;">Settings</a></p>
+                    <button id="fetch-detailed-data" class="blue ui button">Fetch detailed data</button>
+                </div>
+                <ul></ul>
+            </div>
+
+        <div class="ui two cards" id="api-loader" style="display:none;">
             <div class="card" style="min-height: 300px">
                 <div class="ui active dimmer">
                     <div class="ui indeterminate text loader">Waiting for API data</div>


### PR DESCRIPTION
Loading of a complex detailed measurements page can take enormous amounts of time du to the large amount of data transferred and the long query in the database.

Since this value cannot really be brought down, it is already compressed and DB indices are set, this PR shall enable the option to make the data transfer optional.

Especially beginner users do not need the timeline charts and rather use the phase_stats.

See the timing from the developer console attached. The PR brings this down to 10%

<img width="1511" alt="Screenshot 2023-12-15 at 10 33 16 AM" src="https://github.com/green-coding-berlin/green-metrics-tool/assets/250671/4682a91a-f181-459e-ad84-4c3ac143a878">
