### PR TITLE
Added SIGQUIT to nginx and initi to gunicorn, as we are using bash sc…

### DIFF
--- a/docker/compose.yml.example
+++ b/docker/compose.yml.example
@@ -32,6 +32,7 @@ services:
     # should not run on the measurement node anyway
     image: nginx
     container_name: green-coding-nginx-container
+    stop_signal: SIGQUIT
     depends_on:
       - green-coding-postgres
     ports:
@@ -49,6 +50,7 @@ services:
       context: .
       dockerfile: Dockerfile-gunicorn
     container_name: green-coding-gunicorn-container
+    init: true
     depends_on:
       - green-coding-postgres
     restart: always


### PR DESCRIPTION
Our Gunicorn container is using a bash script in the `ENTRYPOINT`. This is not forwarding signals to childs.

Therefore we need to use init so that the container actually tears down immediately on SIGTERM.

Also NGINX prefers a different stop signal. So we supply it

Source: https://docs.docker.com/compose/compose-file/05-services/#init
Source 2: https://docs.docker.com/compose/compose-file/05-services/#stop_signal

