### PR TITLE
Added powercap info to hardware_info

### DIFF
--- a/lib/hardware_info_root_original.py
+++ b/lib/hardware_info_root_original.py
@@ -10,6 +10,7 @@ import re
 from lib.hardware_info import rdr, rpwr, get_values
 
 root_info_list = [
+    [rdr, 'Power Limits', '/sys/devices/virtual/powercap/intel-rapl'],
     [rdr, 'CPU scheduling', '/sys/kernel/debug/sched'],
     [rpwr, 'Hardware Details', 'lshw', r'(?P<o>.*)', re.IGNORECASE | re.DOTALL],
 ]


### PR DESCRIPTION
Adds the RAPL powercapping information from the linux subsystem

```
drwxr-xr-x 6 root root    0 Dec 14 20:06 .
drwxr-xr-x 4 root root    0 Dec 14 20:06 ..
-r--r--r-- 1 root root 4.0K Dec 14 20:06 constraint_0_max_power_uw
-r--r--r-- 1 root root 4.0K Dec 14 20:06 constraint_0_name
-rw-r--r-- 1 root root 4.0K Dec 14 20:06 constraint_0_power_limit_uw
-rw-r--r-- 1 root root 4.0K Dec 14 20:06 constraint_0_time_window_us
-r--r--r-- 1 root root 4.0K Dec 14 20:06 constraint_1_max_power_uw
-r--r--r-- 1 root root 4.0K Dec 14 20:06 constraint_1_name
-rw-r--r-- 1 root root 4.0K Dec 14 20:06 constraint_1_power_limit_uw
-rw-r--r-- 1 root root 4.0K Dec 14 20:06 constraint_1_time_window_us
````

Typical values include the TDP of the chip and currently set power limits