### PR TITLE
Fix check if stderr is empty

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -961,7 +961,7 @@ class Runner:
 
             stderr_read = metric_provider.get_stderr()
             print(f"Stderr check on {metric_provider.__class__.__name__}")
-            if stderr_read is not None and str(stderr_read) is not '':
+            if stderr_read is not None and str(stderr_read):
                 raise RuntimeError(f"Stderr on {metric_provider.__class__.__name__} was NOT empty: {stderr_read}")
 
 
@@ -1095,7 +1095,7 @@ class Runner:
                 continue
 
             stderr_read = metric_provider.get_stderr()
-            if stderr_read is not None and str(stderr_read) is not '':
+            if stderr_read is not None and str(stderr_read):
                 errors.append(f"Stderr on {metric_provider.__class__.__name__} was NOT empty: {stderr_read}")
 
             metric_provider.stop_profiling()


### PR DESCRIPTION
Commit https://github.com/green-coding-berlin/green-metrics-tool/commit/270463c3663b7f5689209f4d934d596bace45d70 by @ribalba lead to the following warnings:

```log
/home/david/green-metrics-tool/runner.py:964: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if stderr_read is not None and str(stderr_read) is not '':
/home/david/green-metrics-tool/runner.py:1098: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if stderr_read is not None and str(stderr_read) is not '':
```

This PR fixes it.