### PR TITLE
Switched from cmd to command

### DIFF
--- a/lib/schema_checker.py
+++ b/lib/schema_checker.py
@@ -102,7 +102,7 @@ class SchemaChecker():
                     Optional("setup-commands"): [str],
                     Optional("volumes"): self.single_or_list(str),
                     Optional("folder-destination"):str,
-                    Optional("cmd"): str,
+                    Optional("command"): str,
                     Optional("log-stdout"): bool,
                     Optional("log-stderr"): bool,
                     Optional("read-notes-stdout"): bool,
@@ -130,6 +130,7 @@ class SchemaChecker():
             Optional("compose-file"): Use(self.validate_compose_include)
         }, ignore_extra_keys=True)
 
+
         # This check is necessary to do in a seperate pass. If tried to bake into the schema object above,
         # it will not know how to handle the value passed when it could be either a dict or list
         if 'networks' in usage_scenario:
@@ -139,6 +140,8 @@ class SchemaChecker():
             service = usage_scenario['services'][service_name]
             if 'image' not in service and 'build' not in service:
                 raise SchemaError("The 'image' key under services is required when 'build' key is not present.")
+            if 'cmd' in service:
+                raise SchemaError("The 'cmd' key under services is not supported anymore. Please migrate to 'command'")
 
         usage_scenario_schema.validate(usage_scenario)
 

--- a/runner.py
+++ b/runner.py
@@ -829,9 +829,6 @@ class Runner:
 
             docker_run_string.append(self.clean_image_name(service['image']))
 
-            if 'cmd' in service:  # must come last
-                docker_run_string.append(service['cmd'])
-
             # Before starting the container, check if the dependent containers are "ready".
             # If not, wait for some time. If the container is not ready after a certain time, throw an error.
             # Currently we consider "ready" only as "running".
@@ -851,14 +848,17 @@ class Runner:
                         )
                         state = status_output.strip()
                         if state == "running":
-                            break;
-                        else:
-                            print(f"State of container '{dependent_container}': {state}. Waiting for 1 second")
-                            self.custom_sleep(1)
-                            time_waited += 1
+                            break
+
+                        print(f"State of container '{dependent_container}': {state}. Waiting for 1 second")
+                        self.custom_sleep(1)
+                        time_waited += 1
 
                     if state != "running":
                         raise RuntimeError(f"Dependent container '{dependent_container}' of '{container_name}' is not running after waiting for {time_waited} sec! Consider checking your service configuration, the entrypoint of the container or the logs of the container.")
+
+            if 'command' in service:  # must come last
+                docker_run_string.append(service['command'])
 
             print(f"Running docker run with: {' '.join(docker_run_string)}")
 

--- a/tests/data/test_cases/subdir_volume_loading/subdir/usage_scenario_subdir.yml
+++ b/tests/data/test_cases/subdir_volume_loading/subdir/usage_scenario_subdir.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./subdir2/testfile2:/tmp/testfile2-correctly-mounted
       - ./subdir2/subdir3/testfile3:/tmp/testfile3-correctly-mounted
-    cmd: sh
+    command: sh
 
 flow:
   - name: Cat Subdir2

--- a/tests/data/usage_scenarios/cmd_stress.yml
+++ b/tests/data/usage_scenarios/cmd_stress.yml
@@ -9,7 +9,7 @@ services:
     type: container
     image: gcb_stress
     build: .
-    cmd: sh
+    command: sh
 
 flow:
   - name: Stress

--- a/tests/test_usage_scenario.py
+++ b/tests/test_usage_scenario.py
@@ -411,7 +411,7 @@ def test_container_is_in_network():
         Tests.cleanup(runner)
     assert 'test-container' in inspect, Tests.assertion_info('test-container', inspect)
 
-# cmd: [str] (optional)
+# command: [str] (optional)
 #    Command to be executed when container is started.
 #    When container does not have a daemon running typically a shell
 #    is started here to have the container running like bash or sh


### PR DESCRIPTION
For unclear reasons the native `command` service top level element in the `docker-compose` specification was implemented as `cmd` in the GMT.

This PR changes this.

https://docs.docker.com/compose/compose-file/compose-file-v2/#command

Note: documentation and example applications have also been changed