### PR TITLE
Euo pipefail

### DIFF
--- a/metric_providers/cpu/frequency/sysfs/core/get-scaling-cur-freq.sh
+++ b/metric_providers/cpu/frequency/sysfs/core/get-scaling-cur-freq.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+set -euo pipefail
 
 cores=$(cat /proc/cpuinfo | grep processor | awk '{print $3}')
 

--- a/metric_providers/cpu/frequency/sysfs/core/provider.py
+++ b/metric_providers/cpu/frequency/sysfs/core/provider.py
@@ -21,4 +21,5 @@ class CpuFrequencySysfsCoreProvider(BaseMetricProvider):
                     file.read()
             except PermissionError as exc:
                 raise MetricProviderConfigurationError(f"{self._metric_name} provider could not be started.\nCannot read the path for the CPU frequency in sysfs.\n\nAre you running in a VM / cloud / shared hosting?\nIf so please disable the {self._metric_name} provider in the config.yml") from exc
-        raise MetricProviderConfigurationError(f"{self._metric_name} provider could not be started.\nCould not find the path for the CPU frequency in sysfs.\n\nAre you running in a VM / cloud / shared hosting? \nIf so please disable the {self._metric_name} provider in the config.yml")
+        else:
+            raise MetricProviderConfigurationError(f"{self._metric_name} provider could not be started.\nCould not find the path for the CPU frequency in sysfs.\n\nAre you running in a VM / cloud / shared hosting? \nIf so please disable the {self._metric_name} provider in the config.yml")

--- a/metric_providers/psu/energy/ac/ipmi/machine/ipmi-get-machine-energy-stat.sh
+++ b/metric_providers/psu/energy/ac/ipmi/machine/ipmi-get-machine-energy-stat.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+set -euo pipefail
 
 i=''
 

--- a/tests/start-test-containers.sh
+++ b/tests/start-test-containers.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 echo "Running docker containers..."
 
 detach=false

--- a/tests/stop-test-containers.sh
+++ b/tests/stop-test-containers.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+set -euo pipefail
+
 echo "Stopping docker containers..."
 docker compose -f ../docker/test-compose.yml down -v --remove-orphans


### PR DESCRIPTION
This PR adds bash guards as `set -euo pipefail`

Just to be safe:
@dan-mm Is there a problem adding these to the test-containers scripts that I might be missing?
@ribalba Is there a problem adding these to the cluster cleanup bash script that I might be missing?