### PR TITLE
Non-Blocking starlette body read

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -84,7 +84,8 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
 @app.exception_handler(StarletteHTTPException)
 async def http_exception_handler(request, exc):
-    await log_exception(request, exc, body='StarletteHTTPException handler cannot read body atm. Waiting for FastAPI upgrade.', details=exc.detail)
+    body = await request.body()
+    await log_exception(request, exc, body=body, details=exc.detail)
     return ORJSONResponse(
         status_code=exc.status_code,
         content=jsonable_encoder({'success': False, 'err': exc.detail}),
@@ -92,17 +93,12 @@ async def http_exception_handler(request, exc):
 
 async def catch_exceptions_middleware(request: Request, call_next):
     #pylint: disable=broad-except
+    body = None
     try:
+        body = await request.body()
         return await call_next(request)
     except Exception as exc:
-        # body = await request.body()  # This blocks the application. Unclear atm how to handle it properly
-        # seems like a bug: https://github.com/tiangolo/fastapi/issues/394
-        # Although the issue is closed the "solution" still behaves with same failure
-        # Actually Starlette, the underlying library to FastAPI has already introduced this functionality:
-        # https://github.com/encode/starlette/pull/1692
-        # However FastAPI does not support the new Starlette 0.31.1
-        # The PR relevant here is: https://github.com/tiangolo/fastapi/pull/9939
-        await log_exception(request, exc, body='Middleware cannot read body atm. Waiting for FastAPI upgrade')
+        await log_exception(request, exc, body=body)
         return ORJSONResponse(
             content={
                 'success': False,

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,6 +1,7 @@
 gunicorn==21.2.0
 psycopg[binary]==3.1.16
 fastapi==0.108.0
+starlette>=0.32
 uvicorn[standard]==0.25.0
 pandas==2.1.4
 PyYAML==6.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ pytest==7.4.3
 requests==2.31.0
 pylint==3.0.3
 fastapi==0.108.0
+starlette>=0.32
 anybadge==1.14.0
 
 # just to clear the pylint errors for the files in /api


### PR DESCRIPTION
Since PR https://github.com/green-coding-berlin/green-metrics-tool/pull/632 was merged we now can add the reading of the body in the GMT on error case in the API.

This was not possible before as the stream was *consumed* and not available anymore after initial parsing of the middleware