### PR TITLE
GMT color via own commit hash

### DIFF
--- a/api/api_helpers.py
+++ b/api/api_helpers.py
@@ -163,7 +163,7 @@ def get_timeline_query(uri, filename, machine_id, branch, metrics, phase, start_
     query = f"""
             SELECT
                 r.id, r.name, r.created_at, p.metric, p.detail_name, p.phase,
-                p.value, p.unit, r.commit_hash, r.commit_timestamp,
+                p.value, p.unit, r.commit_hash, r.commit_timestamp, r.gmt_hash,
                 row_number() OVER () AS row_num
             FROM runs as r
             LEFT JOIN phase_stats as p ON

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -39,13 +39,13 @@ function* colorIterator() {
     }
 }
 
-const generateColoredValues = (values) => {
+const generateColoredValues = (values, key) => {
     const color_iterator = colorIterator()
-    let last_commit_hash = null
+    let last_hash = null
     let color = null;
     return values.map((value) => {
-        if(last_commit_hash != value.commit_hash) {
-            last_commit_hash = value.commit_hash
+        if(last_hash != value[key]) {
+            last_hash = value[key]
             color = color_iterator.next().value
         }
         return {value: value.value, itemStyle: {color: color}}
@@ -159,7 +159,7 @@ const loadCharts = async () => {
     let prun_id = null
 
     phase_stats_data.forEach( (data) => {
-        let [run_id, run_name, created_at, metric_name, detail_name, phase, value, unit, commit_hash, commit_timestamp] = data
+        let [run_id, run_name, created_at, metric_name, detail_name, phase, value, unit, commit_hash, commit_timestamp, gmt_hash] = data
 
 
         if (series[`${metric_name} - ${detail_name}`] == undefined) {
@@ -167,7 +167,7 @@ const loadCharts = async () => {
         }
 
         series[`${metric_name} - ${detail_name}`].labels.push(commit_timestamp)
-        series[`${metric_name} - ${detail_name}`].values.push({value: value, commit_hash: commit_hash})
+        series[`${metric_name} - ${detail_name}`].values.push({value: value, commit_hash: commit_hash, gmt_hash: gmt_hash})
         series[`${metric_name} - ${detail_name}`].notes.push({
             run_name: run_name,
             created_at: created_at,
@@ -176,6 +176,7 @@ const loadCharts = async () => {
             phase: phase,
             run_id: run_id,
             prun_id: prun_id,
+            gmt_hash: gmt_hash,
         })
 
         prun_id = run_id
@@ -203,7 +204,7 @@ const loadCharts = async () => {
 
         const chart_instance = echarts.init(element);
 
-        const my_values = generateColoredValues(series[my_series].values);
+        const my_values = generateColoredValues(series[my_series].values, $('.radio-coloring:checked').val());
 
         let data_series = [{
             name: my_series,
@@ -230,9 +231,11 @@ const loadCharts = async () => {
                         phase: ${series[params.seriesName].notes[params.dataIndex].phase}<br>
                         value: ${numberFormatter.format(series[params.seriesName].values[params.dataIndex].value)}<br>
                         commit_timestamp: ${series[params.seriesName].notes[params.dataIndex].commit_timestamp}<br>
-                        commit_hash: ${series[params.seriesName].notes[params.dataIndex].commit_hash}<br>
+                        commit_hash: <a href="/commit/${series[params.seriesName].notes[params.dataIndex].commit_hash}">${series[params.seriesName].notes[params.dataIndex].commit_hash}</a><br>
+                        gmt_hash: <a href="https://github.com/green-coding-berlin/green-metrics-tool/commit/${series[params.seriesName].notes[params.dataIndex].gmt_hash}">${series[params.seriesName].notes[params.dataIndex].gmt_hash}</a><br>
+
                         <br>
-                        <i>Click to diff measurement with previous</i>
+                        <i>Click the bar to diff measurement with previous</i>
                         `;
             }
         };

--- a/frontend/js/timeline.js
+++ b/frontend/js/timeline.js
@@ -222,29 +222,24 @@ const loadCharts = async () => {
         let options = getLineBarChartOptions([], series[my_series].labels, data_series, 'Time', series[my_series].unit,  'category', null, false, null, true, false, true);
 
         options.tooltip = {
-            trigger: 'item',
+            triggerOn: 'click',
             formatter: function (params, ticket, callback) {
                 if(series[params.seriesName]?.notes == null) return; // no notes for the MovingAverage
                 return `<strong>${series[params.seriesName].notes[params.dataIndex].run_name}</strong><br>
+                        run_id: <a href="/stats.html?id=${series[params.seriesName].notes[params.dataIndex].run_id}"  target="_blank">${series[params.seriesName].notes[params.dataIndex].run_id}</a><br>
                         date: ${series[params.seriesName].notes[params.dataIndex].created_at}<br>
                         metric_name: ${params.seriesName}<br>
                         phase: ${series[params.seriesName].notes[params.dataIndex].phase}<br>
                         value: ${numberFormatter.format(series[params.seriesName].values[params.dataIndex].value)}<br>
                         commit_timestamp: ${series[params.seriesName].notes[params.dataIndex].commit_timestamp}<br>
-                        commit_hash: <a href="/commit/${series[params.seriesName].notes[params.dataIndex].commit_hash}">${series[params.seriesName].notes[params.dataIndex].commit_hash}</a><br>
-                        gmt_hash: <a href="https://github.com/green-coding-berlin/green-metrics-tool/commit/${series[params.seriesName].notes[params.dataIndex].gmt_hash}">${series[params.seriesName].notes[params.dataIndex].gmt_hash}</a><br>
+                        commit_hash: <a href="${$("#uri").text()}/commit/${series[params.seriesName].notes[params.dataIndex].commit_hash}" target="_blank">${series[params.seriesName].notes[params.dataIndex].commit_hash}</a><br>
+                        gmt_hash: <a href="https://github.com/green-coding-berlin/green-metrics-tool/commit/${series[params.seriesName].notes[params.dataIndex].gmt_hash}" target="_blank">${series[params.seriesName].notes[params.dataIndex].gmt_hash}</a><br>
 
                         <br>
-                        <i>Click the bar to diff measurement with previous</i>
+                        👉 <a href="/compare.html?ids=${series[params.seriesName].notes[params.dataIndex].run_id},${series[params.seriesName].notes[params.dataIndex].prun_id}" target="_blank">Diff with previous run</a>
                         `;
             }
         };
-
-        chart_instance.on('click', function (params) {
-            if(params.componentType != 'series') return; // no notes for the MovingAverage
-            window.open(`/compare.html?ids=${series[params.seriesName].notes[params.dataIndex].run_id},${series[params.seriesName].notes[params.dataIndex].prun_id}`, '_blank');
-
-        });
 
         options.dataZoom = {
             show: false,

--- a/frontend/timeline.html
+++ b/frontend/timeline.html
@@ -195,6 +195,21 @@
                                     <i class="info circle icon"></i> Will not affect badge
                                 </div>
                             </div>
+                            <div class="inline fields">
+                                <label>Coloring:</label>
+                                <div class="field">
+                                    <div class="ui radio checkbox">
+                                        <input class="radio-coloring" id="coloring-commit_hash" type="radio" name="coloring" value="commit_hash" checked>
+                                        <label for="coloring-commit_hash">Software commit hash</label>
+                                    </div>
+                                </div>
+                                <div class="field">
+                                    <div class="ui radio checkbox">
+                                        <input class="radio-coloring" id="coloring-gmt_hash" type="radio" name="coloring" value="gmt_hash">
+                                        <label for="coloring-gmt_hash">GMT commit hash</label>
+                                    </div>
+                                </div>
+                            </div>
                             <div class="three fields">
                                 <div class="field">
                                     <label>Start date</label>

--- a/frontend/timeline.html
+++ b/frontend/timeline.html
@@ -37,6 +37,7 @@
     <link rel="stylesheet" type="text/css" href="/css/green-coding.css">
     <style type="text/css">
         .hide-for-single-stats { display: none !important; }
+        .statistics-chart div { pointer-events: all !important }
     </style>
 </head>
 <body class="preload">
@@ -248,7 +249,8 @@
                 <div class="header">
                     Graph Info
                 </div>
-                <p>Graphs show every measurement as a bar. We color the bars according to the commit timestamp and change the color for every new commit. After some time the color repeats ...</p>
+                <p>Graphs show every measurement as a bar. We color the bars according to the commit timestamp and change the color for every new commit (You can also change to color by the GMT tool hash). After some time the color repeats ...</p>
+                <p>To show details click on the bars! A new menu will appear.</p>
             </div>
         </div>
         <div class="ui two cards" id="api-loader">


### PR DESCRIPTION
The GMT can now color in the Timeline view not only by the hash of the tested software, but also by the hash of the GMT itself.

This functionality is used to visually debug energy anomalies when trying to discern wether a change in the software or a change in the tool itself is causing an energy anomaly.

Also the hashes are made clickable in the note. A problem however is that the note itself cannot be clicked in the current form.
@ribalba Do you know of a way to make the note hovering persistent in eCharts?

Sorting GMT:
<img width="1265" alt="Screenshot 2023-12-27 at 12 31 41 PM" src="https://github.com/green-coding-berlin/green-metrics-tool/assets/250671/7aa38fd1-23b5-4c60-b3a7-aab1a46ee11b">

Sorting Software:

<img width="1258" alt="Screenshot 2023-12-27 at 12 31 47 PM" src="https://github.com/green-coding-berlin/green-metrics-tool/assets/250671/8aeabc7e-7ab1-4b46-b15b-8e2c0166b4ba">
