### PR TITLE
Forbidding script to be called with any arguments

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -153,7 +153,7 @@ rm lib/sgx-software-enable/sgx_enable.o
 print_message "Adding hardware_info_root.py to sudoers file"
 PYTHON_PATH=$(which python3)
 PWD=$(pwd)
-echo "ALL ALL=(ALL) NOPASSWD:$PYTHON_PATH $PWD/lib/hardware_info_root.py" | sudo tee /etc/sudoers.d/green_coding_hardware_info
+echo "ALL ALL=(ALL) NOPASSWD:$PYTHON_PATH $PWD/lib/hardware_info_root.py ''" | sudo tee /etc/sudoers.d/green_coding_hardware_info
 
 print_message "Setting the hardare hardware_info to be owned by root"
 sudo cp -f $PWD/lib/hardware_info_root_original.py $PWD/lib/hardware_info_root.py


### PR DESCRIPTION
Although not critical I think we should be explicit. 

The script should only be called without any arguments