### PR TITLE
standardized test-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ metric-provider-binary
 static-binary
 .pytest_cache
 test-compose.yml
-test-config.yml
 tests/structure.sql
 tools/sgx_enable
 venv/

--- a/test-config.yml
+++ b/test-config.yml
@@ -1,67 +1,79 @@
+postgresql:
+  host: test-green-coding-postgres-container
+  user: postgres
+  dbname: test-green-coding
+  password: testpw
+  port: 9573
+
+smtp:
+  server: null
+  sender: null
+  port: null
+  password: null
+  user: null
+
 admin:
-  bcc_email: ''
   email: myemail@dev.local
+  bcc_email: ''
   no_emails: true
+
+
 cluster:
   api_url: http://api.green-coding.internal:9142
+  metrics_url: http://metrics.green-coding.internal:9142
   client:
+    sleep_time_no_job: 300
+    jobs_processing: random
+    time_between_control_workload_validations: 21600
+    send_control_workload_status_mail: false
+    shutdown_on_job_no: false
     control_workload:
+      name: Measurement control Workload
+      uri: https://github.com/green-coding-berlin/measurement-control-workload
+      filename: usage_scenario.yml
       branch: main
       comparison_window: 5
-      filename: usage_scenario.yml
+      threshold: 0.01
+      phase: 004_[RUNTIME]
       metrics:
       - psu_energy_ac_mcp_machine
       - psu_power_ac_mcp_machine
       - cpu_power_rapl_msr_component
       - cpu_energy_rapl_msr_component
-      name: Measurement control Workload
-      phase: 004_[RUNTIME]
-      threshold: 0.01
-      uri: https://github.com/green-coding-berlin/measurement-control-workload
-    jobs_processing: random
-    send_control_workload_status_mail: false
-    shutdown_on_job_no: false
-    sleep_time_no_job: 300
-    time_between_control_workload_validations: 21600
-  metrics_url: http://metrics.green-coding.internal:9142
+
 machine:
-  base_temperature_chip: false
-  base_temperature_feature: false
-  base_temperature_value: false
+  id: 1
   description: Development machine for testing
   error_log_file: false
-  id: 1
+  base_temperature_value: false
+  base_temperature_chip: false
+  base_temperature_feature: false
+
 measurement:
+  idle-time-start: 0
+  idle-time-end: 0
+  flow-process-runtime: 3800
+  phase-transition-time: 1
   boot:
     wait_time_dependencies: 20
-  flow-process-runtime: 3800
-  idle-time-end: 0
-  idle-time-start: 0
   metric-providers:
-    common:
-      psu.energy.ac.sdia.machine.provider.PsuEnergyAcSdiaMachineProvider:
-        CPUChips: 1
-        TDP: 65
-        resolution: 99
     linux:
       cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:
         resolution: 99
     macos: null
-  phase-transition-time: 1
-postgresql:
-  dbname: test-green-coding
-  host: test-green-coding-postgres-container
-  password: testpw
-  port: 9573
-  user: postgres
+    common:
+     psu.energy.ac.xgboost.machine.provider.PsuEnergyAcXgboostMachineProvider:
+       resolution: 99
+       CPUChips: 1
+       HW_CPUFreq: 3200
+       CPUCores: 4
+       CPUThreads: 4
+       TDP: 65
+       HW_MemAmountGB: 16
+       Hardware_Availability_Year: 2011
+
 sci:
   EL: 3.5
-  I: 475
   RS: 1
   TE: 194000
-smtp:
-  password: null
-  port: null
-  sender: null
-  server: null
-  user: null
+  I: 475

--- a/test-config.yml
+++ b/test-config.yml
@@ -1,0 +1,67 @@
+admin:
+  bcc_email: ''
+  email: myemail@dev.local
+  no_emails: true
+cluster:
+  api_url: http://api.green-coding.internal:9142
+  client:
+    control_workload:
+      branch: main
+      comparison_window: 5
+      filename: usage_scenario.yml
+      metrics:
+      - psu_energy_ac_mcp_machine
+      - psu_power_ac_mcp_machine
+      - cpu_power_rapl_msr_component
+      - cpu_energy_rapl_msr_component
+      name: Measurement control Workload
+      phase: 004_[RUNTIME]
+      threshold: 0.01
+      uri: https://github.com/green-coding-berlin/measurement-control-workload
+    jobs_processing: random
+    send_control_workload_status_mail: false
+    shutdown_on_job_no: false
+    sleep_time_no_job: 300
+    time_between_control_workload_validations: 21600
+  metrics_url: http://metrics.green-coding.internal:9142
+machine:
+  base_temperature_chip: false
+  base_temperature_feature: false
+  base_temperature_value: false
+  description: Development machine for testing
+  error_log_file: false
+  id: 1
+measurement:
+  boot:
+    wait_time_dependencies: 20
+  flow-process-runtime: 3800
+  idle-time-end: 0
+  idle-time-start: 0
+  metric-providers:
+    common:
+      psu.energy.ac.sdia.machine.provider.PsuEnergyAcSdiaMachineProvider:
+        CPUChips: 1
+        TDP: 65
+        resolution: 99
+    linux:
+      cpu.utilization.procfs.system.provider.CpuUtilizationProcfsSystemProvider:
+        resolution: 99
+    macos: null
+  phase-transition-time: 1
+postgresql:
+  dbname: test-green-coding
+  host: test-green-coding-postgres-container
+  password: testpw
+  port: 9573
+  user: postgres
+sci:
+  EL: 3.5
+  I: 475
+  RS: 1
+  TE: 194000
+smtp:
+  password: null
+  port: null
+  sender: null
+  server: null
+  user: null

--- a/tests/setup-test-env.py
+++ b/tests/setup-test-env.py
@@ -42,29 +42,6 @@ def copy_sql_structure():
         encoding='UTF-8'
     )
 
-def edit_config_file():
-    print('Creating test-config.yml...')
-    config = None
-    with open(base_config_path, encoding='utf8') as base_config_file:
-        config = yaml.safe_load(base_config_file)
-
-    # Reset SMTP
-    for smtp_entry in config.get('smtp'):
-        config['smtp'][smtp_entry] = None
-
-    config['postgresql']['host'] = 'test-green-coding-postgres-container'
-    config['postgresql']['dbname'] = 'test-green-coding'
-    config['postgresql']['password'] = DB_PW
-    config['admin']['no_emails'] = True
-
-    # change idle start/stop times to 0
-    config['measurement']['idle-time-start'] = 0
-    config['measurement']['idle-time-end'] = 0
-
-    with open(test_config_path, 'w', encoding='utf8') as test_config_file:
-        yaml.dump(config, test_config_file)
-
-
 def edit_compose_file():
     print('Creating test-compose.yml...')
     compose = None
@@ -141,7 +118,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     copy_sql_structure()
-    edit_config_file()
     edit_compose_file()
     edit_etc_hosts()
     if not args.no_docker_build:


### PR DESCRIPTION
Notes:
- only CpuUtilizationProcfsSystemProvider && PsuEnergyAcSdiaMachineProvider turned on at the moment
- if we want, we can use PsuEnergyAcXgboostMachineProvider instead of PsuEnergyAcSdiaMachineProvider, either works (but not both)
- no changes needed for VM as these are the only providers that were running in the VM, but we no longer need to use the disable-metrics-provider script (the script itself is still in, just in case we ever want to use that functionality... but maybe cleanup would be preferred?)
    - example applications will need a small update after merge in order to call the GMT-pytest action correctly (without disable script)
    
- no changes to test-compose.yml or structure.sql (they are also copied). 
    - for test-compose.yml, that is because it copies from compose.yml.example directly, not the user's compose.yml
    - for structure.sql, its because i don't expect the user to be editing that file anyways (and copying makes it easier to keep in sync)
    
- is it ok to have the test-db pw hardcoded here? Other option would be to have it be a variable that is set during the setup-test-env script, but then we get into .gitignore issues (unless we have a test-config.yml.example which is copied over, but that just feels silly at this point)